### PR TITLE
Fix question generator for numbers topic

### DIFF
--- a/pages/api/questionGenerator.ts
+++ b/pages/api/questionGenerator.ts
@@ -33,8 +33,6 @@ export type Question = {
 };
 
 export const generateQuestionsForDiagnostic = (testLength: TestLength, topics: Topic[]) => {
-	console.log(testLength);
-
 	let questionsPerSection = 0;
 	switch (testLength) {
 		case TestLength.SHORT:
@@ -60,9 +58,9 @@ export const generateQuestionsForDiagnostic = (testLength: TestLength, topics: T
 export const generateQuestions = (slug: string, currentLevel: number) => {
 	if (slug != null) {
 		if (slug.toLowerCase() == 'numbers') {
-			return generateQuestionsForTopic(currentLevel, NUM_QUESTIONS, Topic.NUMBERS);
+			return generateQuestionsForTopic(Topic.NUMBERS, currentLevel,  NUM_QUESTIONS);
 		} else {
-			return generateQuestionsForTopic(currentLevel, NUM_QUESTIONS, Topic.ADDITION);
+			return generateQuestionsForTopic(Topic.ADDITION, currentLevel, NUM_QUESTIONS);
 		}
 	}
 	return [];
@@ -81,9 +79,6 @@ function getRandomNumbersQuestion(min: number, max: number): Question {
 }
 
 const generateQuestionsForTopic = (topic: Topic, currentLevel: Difficulty, numberOfQuestions: number) => {
-	console.log('difficulty ', currentLevel);
-	console.log('topic ', topic);
-
 	let questionGenerator: (min: number, max: number) => FlashcardQuestion;
 	switch (topic) {
 		case Topic.NUMBERS:


### PR DESCRIPTION
## Description
The question generator wasn't working before. I changed how it worked when I was working on the diagnostic tool, and I ended up breaking it for the quiz tool. This PR fixes that. 

## Before
<img width="527" alt="Screen Shot 2021-05-03 at 5 37 47 PM" src="https://user-images.githubusercontent.com/4795012/116936775-49205800-ac36-11eb-9561-dd3a27db36cd.png">

## After
<img width="449" alt="Screen Shot 2021-05-03 at 5 38 26 PM" src="https://user-images.githubusercontent.com/4795012/116936859-60f7dc00-ac36-11eb-8238-d8414ef0746d.png">

