### PR TITLE
Add WordProblemDiv to the WordProblem bank of questions

### DIFF
--- a/components/stories/QuestionSet.tsx
+++ b/components/stories/QuestionSet.tsx
@@ -9,6 +9,7 @@ import { VerticalEquation } from "./VerticalEquation";
 import { WordProblemAdd } from "./WordProblemAdd";
 import { WordProblemSub } from "./WordProblemSub";
 import { WordProblemMulti } from "./WordProblemMulti";
+import { WordProblemDiv } from "./WordProblemDiv";
 
 type QuestionSetProps = {
   title: string;
@@ -66,6 +67,15 @@ const QuestionSet = ({
             name={questionData[index].wordProblem.name}
             submitGuess={submitGuess}
             itemContainer={questionData[index].wordProblem.itemContainer}
+            noun1={questionData[index].wordProblem.item1}
+          />
+        );
+      } else if (questionData[index].operator == "÷") {
+        return (
+          <WordProblemDiv
+            question={questionData[index].text}
+            name={questionData[index].wordProblem.name}
+            submitGuess={submitGuess}
             noun1={questionData[index].wordProblem.item1}
           />
         );

--- a/components/stories/WordProblemDiv.tsx
+++ b/components/stories/WordProblemDiv.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from "react";
+import {
+  ItemContainerObj,
+  noun,
+} from "../../pages/api/WordProblemModelObjects";
+import { Button } from "./Button";
+import { Input } from "./Input";
+
+export interface WordProblemDivProp {
+  submitGuess: (e) => void;
+  question: string;
+  name: string;
+  noun1: noun;
+}
+
+/**
+ * The Division Word problem follows a specific template and is as follows:
+ * (name) has a (randomNumber2)(noun.title) and (randomNumber1) friends. (name) wants to share the (noun.title) equally between
+ * their (randomNumber1) friends. How many (noun.title) will each friend have?
+ */
+export const WordProblemDiv: React.FC<WordProblemDivProp> = ({
+  submitGuess,
+  question,
+  name,
+  noun1,
+  ...props
+}) => {
+  const [guess, setGuess] = useState("");
+  const handleKeypress = (e) => {
+    //it triggers by pressing the enter key
+    if (e.charCode === 13) {
+      submitGuess(e);
+    }
+  };
+  const parse = () => {
+    const parts = question.split(" ");
+    return {
+      first: parts[0],
+      second: parts[2],
+    };
+  };
+  const title = (noun, number) => {
+    if (number == "1") {
+      return noun.singleTitle;
+    }
+    return noun.pluralTitle;
+  };
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="text-xl flex flex-wrap">
+        <p className="align-left">
+          {name} has
+          <span className={noun1.colour}>
+            {" " + parse().first}
+            {" " + title(noun1, parse().second) + " "}{" "}
+          </span>
+          <span> and </span>
+          <span className="text-black font-extrabold">
+            {parse().second + " friends"}.
+          </span>
+          {" " + name} wants to share the {title(noun1, parse().first) + " "}
+          equally between them. How many
+          <span className={noun1.colour}>
+            {" " + title(noun1, parse().first) + " "}
+          </span>
+          will each friend have?
+        </p>
+      </div>
+      <div className="text-2xl flex flex-wrap">
+        <Input
+          guess={guess}
+          setGuess={setGuess}
+          handleKeypress={handleKeypress}
+        />
+      </div>
+      <div className="flex flex-wrap mt-2">
+        <img src={noun1.image} width="60px" height="85px" />
+        <img src={noun1.image} width="60px" height="85px" />
+        <img src={noun1.image} width="60px" height="85px" />
+        <img src={noun1.image} width="60px" height="85px" />
+        <img src={noun1.image} width="60px" height="85px" />
+      </div>
+      <Button
+        onClick={submitGuess}
+        label="Submit"
+        backgroundColor="blue"
+        textColor="white"
+      />
+    </div>
+  );
+};

--- a/pages/api/WordProblemModel.tsx
+++ b/pages/api/WordProblemModel.tsx
@@ -70,6 +70,14 @@ export function createWordProblemModel(operator): WordProblemModel {
       item1: itemSelector(itemType),
       item2: itemSelector(itemType),
     };
+  } else if (operator == "/") {
+    return {
+      name: nameSelector(),
+      operator: operator,
+      itemContainer: getRandomItemFromMap(map),
+      nounType: itemType,
+      item1: itemSelector(itemType),
+    };
   } else {
     return {
       name: nameSelector(),

--- a/pages/api/questionGenerator.ts
+++ b/pages/api/questionGenerator.ts
@@ -139,14 +139,19 @@ function getRandomDivisionQuestion(min: number, max: number) {
 	const product = a * b;
 
 	const text = `${product} / ${b} =`;
-	const types = [ QuestionType.LONG_DIVISION_PROBLEM, QuestionType.HORIZONTAL_EQUATION ];
+	const types = [ QuestionType.LONG_DIVISION_PROBLEM, QuestionType.HORIZONTAL_EQUATION, QuestionType.BINARY_WORD_PROBLEM ];
 	const type = types[getRndInteger(0, types.length)];
+	let wordProblemModel;
+	if (type == QuestionType.BINARY_WORD_PROBLEM) {
+		wordProblemModel = createWordProblemModel('÷');
+	}
 
 	return {
 		text: text,
 		answer: a,
 		questionType: type,
-		operator: '÷'
+		operator: '÷',
+		wordProblem: wordProblemModel
 	};
 }
 


### PR DESCRIPTION
This PR does:
- Adds WordProblemDiv allowing for Division Word Problems to be selected as a question
- Diagnostic can now select division word problems as a question
<img width="371" alt="Screen Shot 2021-05-11 at 10 12 33 AM" src="https://user-images.githubusercontent.com/79107199/117831190-5646d380-b242-11eb-830f-5aab06072758.png">
