### PR TITLE
Add disabled property to QuestionSet

### DIFF
--- a/components/stories/QuestionSet.tsx
+++ b/components/stories/QuestionSet.tsx
@@ -26,6 +26,7 @@ type QuestionSetProps = {
   submitGuess: (guessData: GuessData) => void;
   score: number;
   quiz?: boolean;
+  disabled?: boolean;
 };
 
 const QuestionSet = ({
@@ -35,6 +36,7 @@ const QuestionSet = ({
   submitGuess,
   score,
   quiz,
+  disabled = false,
 }: QuestionSetProps) => {
   const questionComponent = () => {
     if (questionData[index].questionType === QuestionType.VERTICAL_EQUATION) {
@@ -169,14 +171,18 @@ const QuestionSet = ({
           {!quiz ? (
             <div>
               Score: {score} / {index + 1}
-
             </div>
           ) : (
             ""
           )}
         </p>
       </div>
-      <Card size="large">{questionData[index] && questionComponent()}</Card>
+      <div>
+        {disabled && (
+          <div className="bg-gray-500 bg-opacity-60 w-96 h-96 fixed z-10" />
+        )}
+        <Card size="large">{questionData[index] && questionComponent()}</Card>
+      </div>
     </div>
   );
 };

--- a/pages/practice/[slug]/[skill].tsx
+++ b/pages/practice/[slug]/[skill].tsx
@@ -81,6 +81,7 @@ const PracticeQuiz = ({ slug, skill }) => {
           inputElement={inputElement}
           submitGuess={submitGuess}
           score={correctGuess}
+          disabled={correctAnswer || wrongAnswer}
         />
         {correctAnswer ? (
           <p>
@@ -112,7 +113,6 @@ const PracticeQuiz = ({ slug, skill }) => {
           ""
         )}
       </div>
-
     </div>
   );
 };


### PR DESCRIPTION
## Problem
We're trying to add functionality to the practice questions so that a student can see immediately when they get an incorrect answer: https://app.asana.com/0/1200180149181635/1200335244571962/f

The problem is that we're not sure what this should exactly look like. 

@harrishanlogan I tried implementing some of the ideas we talked about and I'm not sure I'm satisfied with any of them. Can you look at the screenshots and let me know what you think. Maybe seeing these options will spark some new fourth option that we didn't discuss yet.

FYI @LavaBoy202 @Yaathavi in case either of you have additional ideas.



## Idea 1: Grey out the question
<img width="583" alt="Screen Shot 2021-05-20 at 5 42 43 PM" src="https://user-images.githubusercontent.com/4795012/119052573-cb2cb280-b992-11eb-8ae4-b913d69839e0.png">

Cons: Doesn't look the best, maybe some better styling could help

## Idea 2: Replace the question with feedback
<img width="594" alt="Screen Shot 2021-05-20 at 5 46 34 PM" src="https://user-images.githubusercontent.com/4795012/119052929-54dc8000-b993-11eb-8ae6-e824f8d012ac.png">

Cons: You can't see the question that you just got wrong. maybe we could add the question text into the feedback text

## Idea 3: Popup Modal
<img width="971" alt="Screen Shot 2021-05-20 at 5 55 32 PM" src="https://user-images.githubusercontent.com/4795012/119053804-94f03280-b994-11eb-9fb4-d43febce30da.png">

Cons: Breaks the flow for a student if they see so many popups. Could feel jarring.