### PR TITLE
Fix progress ring on knowledge tree page

### DIFF
--- a/components/Outline.tsx
+++ b/components/Outline.tsx
@@ -65,7 +65,7 @@ export default function Outline() {
             <p className="text-sm mb-4">
               Practice different math-related skills
             </p>
-            <ProgressRing percentage={getOverallProgress()} radius={28} />
+            <ProgressRing percentage={getOverallProgress()} radius={24} />
           </div>
         </Card>
       </div>


### PR DESCRIPTION
It's fixed! I can't screenshot because knowledge tree isn't available on the site that's deployed in vercel. but you can see the /practice page for like a split second, which is how I know it's fixed. 