### PR TITLE
Add grade selector for quiz component for the Topic Overview page

### DIFF
--- a/pages/additionTopicOverview.tsx
+++ b/pages/additionTopicOverview.tsx
@@ -8,20 +8,15 @@ export default function additionTopicOverview(props) {
   const onGradeChange = (e: any) => {
     setGrade(e.target.value);
   };
-  let gradeSet = (grade: string) => {
-    let gradeNum;
+  let gradeNum = (grade: string) => {
     switch (grade) {
       case "Grade 1":
-        gradeNum = 1;
-        break;
+        return 1;
       case "Grade 2":
-        gradeNum = 2;
-        break;
+        return 2;
       case "Grade 3":
-        gradeNum = 3;
-        break;
+        return 3;
     }
-    return gradeNum;
   };
   const cardStyle = (videoId) => {
     return {
@@ -154,7 +149,7 @@ export default function additionTopicOverview(props) {
               <option>Grade 3</option>
             </select>
             <div className="text-white text-xl border-blue-900 font-bold rounded-xl">
-              <Link href={"quiz/addition?level=" + gradeSet(grade)}>
+              <Link href={"quiz/addition?level=" + gradeNum(grade)}>
                 <Button
                   backgroundColor="blue"
                   textColor="white"

--- a/pages/divisionTopicOverview.tsx
+++ b/pages/divisionTopicOverview.tsx
@@ -8,20 +8,15 @@ export default function divisionTopicOverview(props) {
   const onGradeChange = (e: any) => {
     setGrade(e.target.value);
   };
-  let gradeSet = (grade: string) => {
-    let gradeNum;
+  let gradeNum = (grade: string) => {
     switch (grade) {
       case "Grade 1":
-        gradeNum = 1;
-        break;
+        return 1;
       case "Grade 2":
-        gradeNum = 2;
-        break;
+        return 2;
       case "Grade 3":
-        gradeNum = 3;
-        break;
+        return 3;
     }
-    return gradeNum;
   };
   const cardStyle = (videoId) => {
     return {
@@ -150,7 +145,7 @@ export default function divisionTopicOverview(props) {
               <option>Grade 3</option>
             </select>
             <div className="text-white text-xl border-blue-900 font-bold rounded-xl">
-              <Link href={"quiz/division?level=" + gradeSet(grade)}>
+              <Link href={"quiz/division?level=" + gradeNum(grade)}>
                 <Button
                   backgroundColor="blue"
                   textColor="white"

--- a/pages/multiplicationTopicOverview.tsx
+++ b/pages/multiplicationTopicOverview.tsx
@@ -8,20 +8,15 @@ export default function multiplicationTopicOverview(props) {
   const onGradeChange = (e: any) => {
     setGrade(e.target.value);
   };
-  let gradeSet = (grade: string) => {
-    let gradeNum;
+  let gradeNum = (grade: string) => {
     switch (grade) {
       case "Grade 1":
-        gradeNum = 1;
-        break;
+        return 1;
       case "Grade 2":
-        gradeNum = 2;
-        break;
+        return 2;
       case "Grade 3":
-        gradeNum = 3;
-        break;
+        return 3;
     }
-    return gradeNum;
   };
   return (
     <div className="flex flex-col overflow-auto bg-scroll heropattern-piefactory-blue-100 bg-gray-100">
@@ -206,7 +201,7 @@ export default function multiplicationTopicOverview(props) {
                 <option>Grade 3</option>
               </select>
               <div className="text-white text-xl border-blue-900 font-bold rounded-xl">
-                <Link href={"quiz/multiplication?level=" + gradeSet(grade)}>
+                <Link href={"quiz/multiplication?level=" + gradeNum(grade)}>
                   <Button
                     backgroundColor="blue"
                     textColor="white"

--- a/pages/subtractionTopicOverview.tsx
+++ b/pages/subtractionTopicOverview.tsx
@@ -8,20 +8,15 @@ export default function subtractionTopicOverview(props) {
   const onGradeChange = (e: any) => {
     setGrade(e.target.value);
   };
-  let gradeSet = (grade: string) => {
-    let gradeNum;
+  let gradeNum = (grade: string) => {
     switch (grade) {
       case "Grade 1":
-        gradeNum = 1;
-        break;
+        return 1;
       case "Grade 2":
-        gradeNum = 2;
-        break;
+        return 2;
       case "Grade 3":
-        gradeNum = 3;
-        break;
+        return 3;
     }
-    return gradeNum;
   };
   return (
     <div className="flex flex-col overflow-auto bg-scroll heropattern-piefactory-blue-100 bg-gray-100">
@@ -209,7 +204,7 @@ export default function subtractionTopicOverview(props) {
                   <option>Grade 3</option>
                 </select>
                 <div className="text-white text-xl border-blue-900 font-bold rounded-xl">
-                  <Link href={"quiz/subtraction?level=" + gradeSet(grade)}>
+                  <Link href={"quiz/subtraction?level=" + gradeNum(grade)}>
                     <Button
                       backgroundColor="blue"
                       textColor="white"


### PR DESCRIPTION
This PR does:
- Adds a field for grade for the quiz section of the Topic Overview page
- Based on the grade the corresponding quiz difficulty will be generated
<img width="716" alt="Screen Shot 2021-06-08 at 10 52 32 AM" src="https://user-images.githubusercontent.com/79107199/121208255-eda24500-c847-11eb-84cd-ebb922505335.png">
