### PR TITLE
Add carousel to landing page

### DIFF
--- a/components/stories/LandingPage.tsx
+++ b/components/stories/LandingPage.tsx
@@ -9,10 +9,19 @@ import { Button } from "./Button";
 import { Input } from "./Input";
 import Toggle from "./Toggle";
 import { WordProblemAdd } from "./WordProblemAdd";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+import Slider from "react-slick";
 
 const LandingPage = () => {
   const [wordProblem, setWordProblem] = useState(createWordProblemModel("+"));
-
+  var settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
   const onSubmit = () => {
     setWordProblem(createWordProblemModel("+"));
   };
@@ -22,11 +31,11 @@ const LandingPage = () => {
         <div className="flex flex-col w-full sm:w-1/2 gap-8">
           <p className="text-5xl">Math Champ Practice Tracker</p>
           <p className="text-xl">
-            Make math fun to practice! Learning with Math Champ is
-            engaging and fun. Student will earn points for correct answers, play with friends
+            Make math fun to practice! Learning with Math Champ is engaging and
+            fun. Student will earn points for correct answers, play with friends
             and level up. Our curriculum-based lessons are effective and
-            efficient. Start with our diagnostic test so we can help your child learn
-            at whatever level they're at.
+            efficient. Start with our diagnostic test so we can help your child
+            learn at whatever level they're at.
           </p>
           <div className="flex gap-8">
             <Link href="/diagnostic">
@@ -59,7 +68,29 @@ const LandingPage = () => {
           </p>
         </div>
         <div className="sm:w-1/2 m-4 p-4">
-          <WordProblemAdd
+          <div>
+            <Slider {...settings}>
+              <div>
+                <h3>1</h3>
+              </div>
+              <div>
+                <h3>2</h3>
+              </div>
+              <div>
+                <h3>3</h3>
+              </div>
+              <div>
+                <h3>4</h3>
+              </div>
+              <div>
+                <h3>5</h3>
+              </div>
+              <div>
+                <h3>6</h3>
+              </div>
+            </Slider>
+          </div>
+          {/* <WordProblemAdd
             autofocus={false}
             submitGuess={(it) => {
               onSubmit();
@@ -72,7 +103,7 @@ const LandingPage = () => {
               skill: Skill.ADDITION_SINGLE,
               wordProblem: wordProblem,
             }}
-          />
+          /> */}
         </div>
       </div>
       <div className="bg-blue-50 shadow-lg flex flex-col sm:flex-row justify-between rounded-lg">

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "react-modal": "^3.12.1",
     "react-redux": "^7.2.4",
     "react-simple-hook-modal": "^1.1.0",
+    "react-slick": "^0.28.1",
     "react-youtube": "^7.13.1",
+    "slick-carousel": "^1.8.1",
     "tailwindcss": "^2.0.2",
     "tailwindcss-hero-patterns": "0.0.1",
     "uuid": "^8.3.2"


### PR DESCRIPTION

<img width="1564" alt="Screen Shot 2021-06-08 at 9 41 41 PM" src="https://user-images.githubusercontent.com/4795012/121279277-51595c00-c8a2-11eb-8955-75a44936c685.png">

This PR adds a carousel to the landing page. Right now it just shows numbers, but we need to replace that with images of different question types. 