### PR TITLE
Match quiz level to Question asked on the skill Quiz

### DIFF
--- a/pages/api/quiz/quizQuestionGenerator.ts
+++ b/pages/api/quiz/quizQuestionGenerator.ts
@@ -34,7 +34,7 @@ export const generateQuestions = (slug: string, currentLevel: number) => {
           skill = Skill.SUBTRACTION_TRIPLE;
           break;
       }
-      return generateQuestionsForSkill(NUM_QUESTIONS, Skill.SUBTRACTION_SINGLE);
+      return generateQuestionsForSkill(NUM_QUESTIONS, skill);
     } else if (slug.toLowerCase() == "multiplication") {
       let skill;
       switch (currentLevel) {
@@ -42,7 +42,7 @@ export const generateQuestions = (slug: string, currentLevel: number) => {
           skill = Skill.EQUAL_GROUP_10_ITEMS;
           break;
         case 2:
-          skill = Skill.MULTIPLICATION_10;
+          skill = Skill.MULTIPLICATION_5;
           break;
         case 3:
           skill = Skill.MULTIPLICATION_10;


### PR DESCRIPTION
This PR does:
- Fixes the bug where the skill level of the quiz doesn't match to the questions asked
- Visit this asana card for more detail: https://app.asana.com/0/1200180149181635/1200453843029263/f
