### PR TITLE
Hide practice for now

### DIFF
--- a/components/DiagnosticNavbar.tsx
+++ b/components/DiagnosticNavbar.tsx
@@ -91,12 +91,6 @@ export default function Navbar() {
             <div className="hidden sm:block sm:ml-6">
               <div className="flex space-x-4">
                 <a
-                  href="/practice"
-                  className="bg-gray-900 text-white px-3 py-2 rounded-md text-sm font-medium"
-                >
-                  Practice
-                </a>
-                <a
                   href="/diagnostic"
                   className="bg-gray-900 text-white px-3 py-2 rounded-md text-sm font-medium"
                 >
@@ -129,12 +123,6 @@ export default function Navbar() {
       <div className={`${active ? "block" : "hidden"} sm:hidden`}>
         <div className="px-2 pt-2 pb-3 space-y-1">
           {/* <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" --> */}
-          <a
-            href="/practice"
-            className="bg-gray-900 text-white block px-3 py-2 rounded-md text-base font-medium"
-          >
-            Practice
-          </a>
           <a
             href="/diagnostic"
             className="bg-gray-900 text-white block px-3 py-2 rounded-md text-base font-medium"


### PR DESCRIPTION
This PR hides the practice link for now. It'll allow us to still show the site and get feedback on the assessment. We'll add it back when we're ready to launch the practice tracker.
<img width="574" alt="Screen Shot 2021-06-25 at 6 50 06 PM" src="https://user-images.githubusercontent.com/4795012/123491990-2a12c680-d5e6-11eb-8179-c762a524e6f4.png">
