### PR TITLE
Add users to our user table

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -11,8 +11,8 @@ export default NextAuth({
     }),
     Providers.Google({
       clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET
-    })
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    }),
     // ...add more providers here
   ],
   callbacks: {
@@ -21,7 +21,40 @@ export default NextAuth({
       return Promise.resolve(session);
     },
     async redirect(url, baseUrl) {
-      return baseUrl + "/practice"
-    }
+      return baseUrl + "/practice";
+    },
+    async jwt(token, user, account, profile, isNewUser) {
+      userSync(token)
+      return token;
+    },
   },
 });
+
+const userSync = async (token) => {
+  const userId = token.sub;
+  const nickname = token.name;
+  const url = "https://talented-duckling-40.hasura.app/v1/graphql";
+  const upsertUserQuery = `
+    mutation ($userId: String!, $name:String){
+  insert_users(objects: [{ id: $userId, name:$name }], on_conflict: { constraint: users_pkey, update_columns: [] }) {
+    affected_rows
+  }
+}
+`;
+  // TODO if user was already in the user table, then update the last seen column
+  // If the user was newly added to the user table, then initialize their skills, and badges
+  // Then we can remove the initialization checks in the practice tracker
+  const graphqlReq = {
+    query: upsertUserQuery,
+    variables: { userId: userId, name: nickname },
+  };
+
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET,
+    },
+    body: JSON.stringify(graphqlReq),
+  })
+};


### PR DESCRIPTION
When we switched from Auth0 to Google Sign in, we lost functionality where Auth0 would insert new users into our Hasura Users table for us. 

This PR manually does that now. I implemented this using the next-auth library's callback feature.

We should move all user initialization into this function. Initialization of badges and skills happens everytime a user opens the knowledge tree. We should do that in this function instead.