### PR TITLE
Lock Numbers and Fractions Topics 

### DIFF
--- a/pages/api/topics.ts
+++ b/pages/api/topics.ts
@@ -10,13 +10,13 @@ export const lockedTopics = [
   "Data",
   "Variables",
   "Stats",
+  "Numbers",
+  "Fractions",
 ];
 
 export const unlockedTopics = [
-  { title: "Numbers", image: "/images/skills/numbers.png" },
   { title: "Addition", image: "/images/skills/addition.png" },
   { title: "Subtraction", image: "/images/skills/subtraction.png" },
   { title: "Multiplication", image: "/images/skills/multiplication.png" },
   { title: "Division", image: "/images/skills/division.png" },
-  { title: "Fractions", image: "" },
 ];


### PR DESCRIPTION
This PR does: 
- Locks the Fractions and Numbers topic so that it can't be accessed by the user
<img width="917" alt="Screen Shot 2021-07-01 at 10 50 58 AM" src="https://user-images.githubusercontent.com/79107199/124144875-58ffc100-da5a-11eb-803e-d7cb6f87e5e2.png">
