### PR TITLE
Create flippable locked badge component

### DIFF
--- a/components/LockedBadge.tsx
+++ b/components/LockedBadge.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from "react";
+import ReactCardFlip from "react-card-flip";
+
+interface LockedBadgeProps {
+  title: string;
+}
+
+const LockedBadge = ({ title }: LockedBadgeProps) => {
+  const [isFlipped, setIsFlipped] = useState(false);
+  const toggleFlip = () => {
+    setIsFlipped(!isFlipped);
+  };
+  return (
+    <ReactCardFlip
+      isFlipped={isFlipped}
+      flipDirection="vertical"
+      infinite={true}
+    >
+      <div onClick={toggleFlip}>
+        <img src="/images/lockedPic.png" className="w-32" />
+      </div>
+      <div onClick={toggleFlip} className="w-32 h-32 rounded-xl bg-gray-500 flex justify-center items-center">
+        <p className="text-white font-bold text-center">{title}</p>
+      </div>
+    </ReactCardFlip>
+  );
+};
+
+export default LockedBadge;

--- a/components/ProfileComponent.tsx
+++ b/components/ProfileComponent.tsx
@@ -5,6 +5,8 @@ import { EMOJI_MASTERY, getEmoji } from "../pages/api/skill";
 import { FETCH_USER_PROFILE } from "../graphql/fetchUserProfile";
 import { useQuery } from "@apollo/client";
 import Link from "next/link";
+import ReactCardFlip from "react-card-flip";
+import LockedBadge from "./LockedBadge";
 
 const ProfileComponent = () => {
   const [session] = useSession();
@@ -95,9 +97,7 @@ const ProfileComponent = () => {
               {data &&
                 data.user_badges.map((badge) => {
                   return badge.locked ? (
-                    <div className="">
-                      <img src="/images/lockedPic.png" className="w-32" />
-                    </div>
+                    <LockedBadge title={badge.badge.title} />
                   ) : (
                     <Link href={`/badges/${badge.badge.id}`}>
                       <img
@@ -124,6 +124,6 @@ const ProfileComponent = () => {
       </div>
     </div>
   );
-}
+};
 
 export default ProfileComponent;


### PR DESCRIPTION
This PR uses a flipcard with the locked badge to create a re-usable component

<img width="727" alt="Screen Shot 2021-08-03 at 11 19 14 PM" src="https://user-images.githubusercontent.com/4795012/128116873-3a3a2877-5823-4985-be87-e9b9114db4ed.png">
