### PR TITLE
Preload the user session for protected pages

### DIFF
--- a/components/Outline.tsx
+++ b/components/Outline.tsx
@@ -1,4 +1,4 @@
-import React, {  } from "react";
+import React from "react";
 import { PracticeTopic } from "./PracticeTopic";
 import { useSession } from "next-auth/client";
 import { userId } from "../graphql/utils/constants";
@@ -8,9 +8,13 @@ import { lockedTopics, unlockedTopics } from "../pages/api/topics";
 import { EMOJI_MASTERY } from "../pages/api/skill";
 import { FETCH_USER_PROFILE } from "../graphql/fetchUserProfile";
 import { useQuery } from "@apollo/client";
-export default function Outline() {
-  const [session] = useSession();
+import { Session } from "next-auth";
 
+interface OutlineProps {
+  session: Session;
+}
+
+export default function Outline({ session }: OutlineProps) {
   let { loading, data } = useQuery(FETCH_USER_PROFILE, {
     variables: {
       userId: userId(session),
@@ -18,22 +22,27 @@ export default function Outline() {
   });
 
   const progress = () => {
-    if (!loading && data.user_badges.length > 0 && data.user_skills.length > 0) {
+    if (
+      !loading &&
+      data.user_badges.length > 0 &&
+      data.user_skills.length > 0
+    ) {
       const unlockedBadges = data.user_badges.filter(
         (it) => it.locked == false
       );
       const masteredSkills = data.user_skills.filter(
         (it) => it.emoji > EMOJI_MASTERY
       );
-      
+
       return Math.round(
-        ((unlockedBadges.length + masteredSkills.length) * 100) / (data.user_badges.length + data.user_skills.length)
+        ((unlockedBadges.length + masteredSkills.length) * 100) /
+          (data.user_badges.length + data.user_skills.length)
       );
     } else {
       return 0;
     }
   };
-  
+
   const loggedInComponent = (
     <div className="max-w-screen-lg">
       <div className="flex justify-center mb-8 mt-4">
@@ -41,7 +50,8 @@ export default function Outline() {
           <div className="flex flex-col gap-8 items-center">
             <p className="text-xl font-bold font-sans">Math Knowledge Tree</p>
             <p className="text-sm mb-4">
-              Practice skills to increase your math confidence. Then ace your quizzes to unlock badges!
+              Practice skills to increase your math confidence. Then ace your
+              quizzes to unlock badges!
             </p>
             <ProgressRing percentage={progress()} radius={24} />
           </div>

--- a/components/ProfileComponent.tsx
+++ b/components/ProfileComponent.tsx
@@ -1,16 +1,17 @@
 import React, { useState } from "react";
-import { useSession } from "next-auth/client";
 import { userId } from "../graphql/utils/constants";
 import { EMOJI_MASTERY, getEmoji } from "../pages/api/skill";
 import { FETCH_USER_PROFILE } from "../graphql/fetchUserProfile";
 import { useQuery } from "@apollo/client";
 import Link from "next/link";
-import ReactCardFlip from "react-card-flip";
 import LockedBadge from "./LockedBadge";
+import { Session } from "next-auth";
 
-const ProfileComponent = () => {
-  const [session] = useSession();
+interface ProfileComponentProps {
+  session: Session;
+}
 
+const ProfileComponent = ({ session }: ProfileComponentProps) => {
   let { loading, data } = useQuery(FETCH_USER_PROFILE, {
     variables: {
       userId: userId(session),

--- a/pages/practice.tsx
+++ b/pages/practice.tsx
@@ -1,8 +1,11 @@
 import Head from "next/head";
 import Outline from "../components/Outline";
 import DiagnosticNavbar from "../components/DiagnosticNavbar";
+import { getSession, useSession } from "next-auth/client";
 
 export default function Home() {
+  const [session, loading] = useSession();
+
   return (
     <div className="flex flex-col h-screen">
       <div>
@@ -15,10 +18,19 @@ export default function Home() {
           )`,
         }}
       >
-        <Outline />
+        <Outline session={session} />
       </div>
     </div>
   );
 }
 
-Home.auth = true
+Home.auth = true;
+
+// Export the `session` prop to use sessions with Server Side Rendering
+export async function getServerSideProps(context) {
+  return {
+    props: {
+      session: await getSession(context),
+    },
+  };
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,16 +1,28 @@
+import { getSession, useSession } from "next-auth/client";
 import React from "react";
 import DiagnosticNavbar from "../components/DiagnosticNavbar";
 import ProfileComponent from "../components/ProfileComponent";
 
 const Profile = () => {
+  const [session, loading] = useSession();
+
   return (
     <div>
       <DiagnosticNavbar />
-      <ProfileComponent />
-      </div>
+      <ProfileComponent session={session} />
+    </div>
   );
-}
+};
 
 export default Profile;
 
-Profile.auth = true
+Profile.auth = true;
+
+// Export the `session` prop to use sessions with Server Side Rendering
+export async function getServerSideProps(context) {
+  return {
+    props: {
+      session: await getSession(context),
+    },
+  };
+}


### PR DESCRIPTION
This PR fetches the user session at build time on the server for the profile and practice pages. Previously we were always fetching the user session on the client (the web browser) and it was failing sporadically. Hopefully this change will ensure that the session is always available and will prevent users from randomly getting logged out. 