### PR TITLE
Save student guesses to the db as they do the assignment

### DIFF
--- a/graphql/userAssignments/createUserAssignment.ts
+++ b/graphql/userAssignments/createUserAssignment.ts
@@ -1,0 +1,18 @@
+import { gql } from "@apollo/client";
+
+export const CREATE_USER_ASSIGNMENT = gql`
+  mutation insertUserAssignment($user_id: String, $assignment_id: String) {
+    insert_user_assignments(
+      objects: {
+        assignment_id: $assignment_id
+        user_id: $user_id
+        user_solution: {}
+      }
+    ) {
+      returning {
+        id
+        user_solution
+      }
+    }
+  }
+`;

--- a/graphql/userAssignments/fetchUserAssignment.ts
+++ b/graphql/userAssignments/fetchUserAssignment.ts
@@ -1,0 +1,16 @@
+import { gql } from "@apollo/client";
+
+export const FETCH_USER_ASSIGNMENT = gql`
+  query fetchUserAssignment($assignment_id: String, $user_id: String) {
+    user_assignments(
+      where: {
+        assignment_id: { _eq: $assignment_id }
+        user_id: { _eq: $user_id }
+      }
+    ) {
+      user_id
+      assignment_id
+      user_solution
+    }
+  }
+`;

--- a/graphql/userAssignments/updateUserAssignment.ts
+++ b/graphql/userAssignments/updateUserAssignment.ts
@@ -1,0 +1,22 @@
+import { gql } from "@apollo/client";
+
+export const UPDATE_USER_ASSIGNMENT = gql`
+  mutation updateUserAssignment(
+    $user_id: String
+    $user_solution: jsonb
+    $assignment_id: String
+  ) {
+    update_user_assignments(
+      where: {
+        assignment_id: { _eq: $assignment_id }
+        user_id: { _eq: $user_id }
+      }
+      _set: { user_solution: $user_solution }
+    ) {
+      returning {
+        id
+        user_solution
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Background 
We want to save the student guesses to the db as the student is completing the assignment. This will allow student submissions to be saved and retrieved later so students don't have to do the entire assignment in one shot. Also, later we will allow teachers to release solutions to the student. So we will need to display the student solutions beside the actual solutions.

## Next Steps
- save the Show Your Work drawings to the DB
- show real solutions alongside student solution when teacher reveals solutions

## Verification Steps
- [x] Answer a few questions, and refresh the page. Verify that guesses were saved 