### PR TITLE
Show all student submissions on teacher dashboard

### DIFF
--- a/graphql/userAssignments/createUserAssignment.ts
+++ b/graphql/userAssignments/createUserAssignment.ts
@@ -1,12 +1,12 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_USER_ASSIGNMENT = gql`
-  mutation insertUserAssignment($user_id: String, $assignment_id: String) {
+  mutation insertUserAssignment($user_id: String, $assignment_id: String, $user_solution: jsonb) {
     insert_user_assignments(
       objects: {
         assignment_id: $assignment_id
         user_id: $user_id
-        user_solution: {}
+        user_solution: $user_solution
       }
     ) {
       returning {

--- a/pages/teachers/cye1.tsx
+++ b/pages/teachers/cye1.tsx
@@ -47,6 +47,9 @@ export default function cye1(props) {
       },
       onCompleted: (data: any) => {
         console.log("data", data);
+        if (data.user_assignments.length > 0) {
+          setGuesses(data.user_assignments[0].user_solution);
+        }
       },
     }
   );
@@ -66,6 +69,7 @@ export default function cye1(props) {
         variables: {
           user_id: userId(session),
           assignment_id: "cye1",
+          user_solution: ["", "", "", "", "", "", "", "", "", "", "", "", "", ""]
         },
         refetchQueries: [
           {
@@ -77,12 +81,6 @@ export default function cye1(props) {
           },
         ],
       });
-    } else if (
-      session &&
-      userAssignmentFetchData &&
-      userAssignmentFetchData.user_assignments.length > 0
-    ) {
-      setGuesses(userAssignmentFetchData.user_assignments[0].user_solution);
     }
   }, [userAssignmentFetchData]);
 
@@ -91,7 +89,7 @@ export default function cye1(props) {
     updateUserAssignment({
       variables: {
         user_id: userId(session),
-        assignment_id: "cye-1",
+        assignment_id: "cye1",
         user_solution: guesses,
       },
       refetchQueries: [
@@ -99,7 +97,7 @@ export default function cye1(props) {
           query: FETCH_USER_ASSIGNMENT,
           variables: {
             userId: userId(session),
-            assignment_id: "cye-1",
+            assignment_id: "cye1",
           },
         },
       ],
@@ -113,7 +111,7 @@ export default function cye1(props) {
     updateUserAssignment({
       variables: {
         user_id: userId(session),
-        assignment_id: "cye-1",
+        assignment_id: "cye1",
         user_solution: guesses,
       },
       refetchQueries: [
@@ -121,7 +119,7 @@ export default function cye1(props) {
           query: FETCH_USER_ASSIGNMENT,
           variables: {
             userId: userId(session),
-            assignment_id: "cye-1",
+            assignment_id: "cye1",
           },
         },
       ],

--- a/pages/teachers/dashboard/[slug].tsx
+++ b/pages/teachers/dashboard/[slug].tsx
@@ -19,21 +19,34 @@ const TeacherDashboardPage = ({ data }) => {
   return (
     <div className="flex flex-col overflow-auto bg-scroll heropattern-architect-blue-200 bg-blue-100 h-screen">
       <Navbar />
-      {JSON.stringify(data)}
       {data && data.user_assignments && data.user_assignments[0] && (
-        <div className="bg-white m-4 p-4 rounded-xl shadow-lg flex flex-col gap-8">
-          <p className="font-bold">{data.user_assignments[0].user.name}</p>
-          {data.user_assignments[0].user_solution.map((guess, index) => (
-            <div className="flex flex-col gap-2 p-4 items-center border-b-4 border-blue-400">
-              <p className="">Question #{index}</p>
-              <div>
-                <TeX block>{questions[index]}</TeX>
-              </div>
-              <p>
-                Student's Answer: <span className="font-bold">{guess}</span>
-              </p>
-            </div>
-          ))}
+        <div className="flex flex-col">
+          <h1 className="text-center font-bold text-xl p-4">Assignment Id: {data.user_assignments[0].assignment_id}</h1>
+          <div className="bg-white mb-4 mx-4 p-4 rounded-xl shadow-lg flex flex-col gap-8">
+            <select
+              value={currentStudentIndex}
+              onChange={(e) =>
+                setCurrentStudentIndex(Number.parseInt(e.target.value))
+              }
+            >
+              {data.user_assignments.map((student, index) => (
+                <option value={index}>{student.user.name}</option>
+              ))}
+            </select>
+            {data.user_assignments[currentStudentIndex].user_solution.map(
+              (guess, index) => (
+                <div className="flex flex-col gap-2 p-4 items-center border-b-4 border-blue-400">
+                  <p className="">Question #{index}</p>
+                  <div>
+                    <TeX block>{questions[index]}</TeX>
+                  </div>
+                  <p>
+                    Student's Answer: <span className="font-bold">{guess}</span>
+                  </p>
+                </div>
+              )
+            )}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
This PR adds a dropdown, so the teacher can select which student's responses they want to look at in the dashboard. It also has graphQL fixes that were required to support this change.