### PR TITLE
Save student images to db

### DIFF
--- a/components/ui/FreeDrawing.tsx
+++ b/components/ui/FreeDrawing.tsx
@@ -1,7 +1,4 @@
 import React from "react";
-import { useEffect } from "react";
-import { useState } from "react";
-import { render } from "react-dom";
 import { Stage, Layer, Line, Text } from "react-konva";
 import useWindowSize from "../../hooks/UseWindowSizeHook";
 import { Button } from "./Button";
@@ -11,6 +8,7 @@ interface FreeDrawingProps {
   setLines: (lines: LineData[]) => void;
   historyStep: number;
   setHistoryStep: (step: number) => void;
+  saveImage: (image: string) => void;
 }
 
 export type LineData = {
@@ -23,7 +21,10 @@ const FreeDrawing = ({
   setLines,
   historyStep,
   setHistoryStep,
+  saveImage
 }: FreeDrawingProps) => {
+  const stageRef = React.useRef(null);
+
   const [tool, setTool] = React.useState("black");
   const isDrawing = React.useRef(false);
   const { width, height } = useWindowSize();
@@ -85,6 +86,7 @@ const FreeDrawing = ({
 
   const handleMouseUp = () => {
     isDrawing.current = false;
+    saveImage(stageRef.current.toDataURL());
   };
 
   return (
@@ -95,6 +97,7 @@ const FreeDrawing = ({
       </div>
       <Stage
         style={{ touchAction: "none" }}
+        ref={stageRef}
         width={width}
         height={height}
         onMouseDown={handleMouseDown}

--- a/graphql/userAssignments/createUserAssignment.ts
+++ b/graphql/userAssignments/createUserAssignment.ts
@@ -1,17 +1,19 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_USER_ASSIGNMENT = gql`
-  mutation insertUserAssignment($user_id: String, $assignment_id: String, $user_solution: jsonb) {
+  mutation insertUserAssignment($user_id: String, $assignment_id: String, $user_solution: jsonb, $user_images: jsonb) {
     insert_user_assignments(
       objects: {
         assignment_id: $assignment_id
         user_id: $user_id
         user_solution: $user_solution
+        user_images: $user_images
       }
     ) {
       returning {
         id
         user_solution
+        user_images
       }
     }
   }

--- a/graphql/userAssignments/updateUserAssignment.ts
+++ b/graphql/userAssignments/updateUserAssignment.ts
@@ -4,6 +4,7 @@ export const UPDATE_USER_ASSIGNMENT = gql`
   mutation updateUserAssignment(
     $user_id: String
     $user_solution: jsonb
+    $user_images: jsonb
     $assignment_id: String
   ) {
     update_user_assignments(
@@ -11,7 +12,7 @@ export const UPDATE_USER_ASSIGNMENT = gql`
         assignment_id: { _eq: $assignment_id }
         user_id: { _eq: $user_id }
       }
-      _set: { user_solution: $user_solution }
+      _set: { user_solution: $user_solution, user_images: $user_images }
     ) {
       returning {
         id

--- a/pages/teachers/cye1.tsx
+++ b/pages/teachers/cye1.tsx
@@ -26,7 +26,9 @@ enum Stage {
 }
 
 export default function cye1(props) {
+  const EMPTY_ARRAY = ["", "", "", "", "", "", "", "", "", "", "", "", "", ""];
   const [guesses, setGuesses] = useState<string[]>([]);
+  const [images, setImages] = useState<string[]>([]);
   const [stage, setStage] = useState(Stage.RULES);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [historyStepForQuestions, setHistoryStepForQuestions] = useState<
@@ -35,7 +37,6 @@ export default function cye1(props) {
   const [linesForQuestions, setLinesForQuestions] = React.useState<
     LineData[][]
   >([]);
-  const [userSolution, setUserSolution] = useState({});
   const [session] = useSession();
 
   const { loading, data: userAssignmentFetchData } = useQuery(
@@ -49,6 +50,11 @@ export default function cye1(props) {
         console.log("data", data);
         if (data.user_assignments.length > 0) {
           setGuesses(data.user_assignments[0].user_solution);
+          if (data.user_assignments[0].user_images) {
+            setImages(data.user_assignments[0].user_images);
+          } else {
+            setImages(EMPTY_ARRAY);
+          }
         }
       },
     }
@@ -69,7 +75,8 @@ export default function cye1(props) {
         variables: {
           user_id: userId(session),
           assignment_id: "cye1",
-          user_solution: ["", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+          user_solution: EMPTY_ARRAY,
+          user_images: EMPTY_ARRAY,
         },
         refetchQueries: [
           {
@@ -84,6 +91,17 @@ export default function cye1(props) {
     }
   }, [userAssignmentFetchData]);
 
+  const updateImage = (uri: string) => {
+    const newImages = images.map((image, index) => {
+      if (index === currentQuestionIndex) {
+        return uri;
+      } else {
+        return image;
+      }
+    });
+    setImages(newImages);
+  };
+
   const onNextQuestion = () => {
     // update user assignment and cache the returned assignment
     updateUserAssignment({
@@ -91,6 +109,7 @@ export default function cye1(props) {
         user_id: userId(session),
         assignment_id: "cye1",
         user_solution: guesses,
+        user_images: images,
       },
       refetchQueries: [
         {
@@ -113,6 +132,7 @@ export default function cye1(props) {
         user_id: userId(session),
         assignment_id: "cye1",
         user_solution: guesses,
+        user_images: images,
       },
       refetchQueries: [
         {
@@ -167,7 +187,6 @@ export default function cye1(props) {
   };
 
   useEffect(() => {
-    setGuesses(["", "", "", "", "", "", "", "", "", "", "", "", "", ""]);
     setLinesForQuestions([
       [],
       [],
@@ -237,6 +256,7 @@ export default function cye1(props) {
                 onChange={(e) => onGuessChanged(e.target.value)}
               ></input>
               <FreeDrawing
+                saveImage={updateImage}
                 lines={linesForQuestions[currentQuestionIndex]}
                 setLines={setLinesForCurrentQuestion}
                 historyStep={historyStepForQuestions[currentQuestionIndex]}


### PR DESCRIPTION
This PR saves student images to the db. We have a `FreeDrawing` component that uses the react-konva library to handle drawing on the screen. Konva has a `toDataURL()` method that exports the current drawing to a byte64 data string. We store that string in the database. 

Next PR will render these drawings on the teacher dashboard