### PR TITLE
add disable next functionality

### DIFF
--- a/components/foodtruck/LaborCostEquation.tsx
+++ b/components/foodtruck/LaborCostEquation.tsx
@@ -11,6 +11,9 @@ export interface LaborCostEquationProps {
   selectedTruck: Truck;
   selectedNumWorkers: string;
 
+  laborCostComponentComplete: boolean;
+  setLaborCostComponentComplete: (laborCostComponentComplete: boolean) => void;
+
   laborCostEquationOneBoxOne: string;
   setLaborCostEquationOneBoxOne: (laborCostEquationOneBoxOne: string) => void;
   laborCostEquationOneBoxTwo: string;
@@ -38,6 +41,8 @@ const LaborCostEquation = ({
   selectedFood,
   selectedTruck,
   selectedNumWorkers,
+  laborCostComponentComplete,
+  setLaborCostComponentComplete,
   laborCostEquationOneBoxOne,
   setLaborCostEquationOneBoxOne,
   laborCostEquationOneBoxTwo,
@@ -99,6 +104,10 @@ const LaborCostEquation = ({
       validateLaborCostEquationOneAnswer() &&
       validateLaborCostEquationTwoAnswer()
     );
+  };
+
+  const passLaborCostComponent = () => {
+    setLaborCostComponentComplete(validateComponent());
   };
 
   const equationContainerCSS = (
@@ -239,7 +248,10 @@ const LaborCostEquation = ({
             validateLaborCostEquationTwoAnswer()
           )}
           value={laborCostEquationTwoBoxFour}
-          onChange={(e) => setLaborCostEquationTwoBoxFour(e.target.value)}
+          onChange={(e) => {
+            setLaborCostEquationTwoBoxFour(e.target.value);
+            passLaborCostComponent();
+          }}
           placeholder="2"
         />
       </div>

--- a/components/foodtruck/ProdCostEquation.tsx
+++ b/components/foodtruck/ProdCostEquation.tsx
@@ -1,3 +1,4 @@
+import { validate } from "graphql";
 import React from "react";
 import { Food, operatingHours, Truck } from "../../pages/api/foodtruck/food";
 
@@ -5,7 +6,8 @@ export interface ProdCostEquationProps {
   selectedFood: Food;
   selectedTruck: Truck;
   selectedNumWorkers: string;
-
+  prodCostComponentComplete: boolean;
+  setProdCostComponentComplete: (prodCostComponent: boolean) => void;
   prodCostEquationOneBoxOne: string;
   setProdCostEquationOneBoxOne: (prodCostEquationOneBoxOne: string) => void;
   prodCostEquationOneBoxTwo: string;
@@ -29,6 +31,8 @@ const ProdCostEquation = ({
   selectedFood,
   selectedTruck,
   selectedNumWorkers,
+  prodCostComponentComplete,
+  setProdCostComponentComplete,
   prodCostEquationOneBoxOne,
   setProdCostEquationOneBoxOne,
   prodCostEquationOneBoxTwo,
@@ -87,6 +91,10 @@ const ProdCostEquation = ({
     return (
       validateProdCostEquationOneAnswer() && validateProdCostEquationTwoAnswer()
     );
+  };
+
+  const passProdCostComponent = () => {
+    setProdCostComponentComplete(validateComponent());
   };
 
   const equationContainerCSS = (
@@ -233,7 +241,10 @@ const ProdCostEquation = ({
             validateProdCostEquationTwoAnswer()
           )}
           value={prodCostEquationTwoBoxFour}
-          onChange={(e) => setProdCostEquationTwoBoxFour(e.target.value)}
+          onChange={(e) => {
+            setProdCostEquationTwoBoxFour(e.target.value);
+            passProdCostComponent();
+          }}
           placeholder="2"
         />
       </div>

--- a/components/foodtruck/RevenueEquation.tsx
+++ b/components/foodtruck/RevenueEquation.tsx
@@ -5,6 +5,10 @@ export interface RevenueEquationProps {
   selectedFood: Food;
   selectedNumWorkers: string;
   revEquationOneBoxOne: string;
+  revenueComponentComplete: boolean;
+
+  setRevenueComponentComplete: (revenueComponentComplete: boolean) => void;
+
   setRevEquationOneBoxOne: (revEquationOneBoxOne: string) => void;
   revEquationOneBoxTwo: string;
   setRevEquationOneBoxTwo: (revEquationOneBoxTwo: string) => void;
@@ -23,6 +27,8 @@ export interface RevenueEquationProps {
 const RevenueEquation = ({
   selectedFood,
   selectedNumWorkers,
+  revenueComponentComplete,
+  setRevenueComponentComplete,
   revEquationOneBoxOne,
   setRevEquationOneBoxOne,
   revEquationOneBoxTwo,
@@ -76,6 +82,10 @@ const RevenueEquation = ({
 
   const validateComponent = () => {
     return validateQuestionOneAnswer() && validateQuestionTwoAnswer();
+  };
+
+  const passRevenueComponent = () => {
+    setRevenueComponentComplete(validateComponent());
   };
 
   const equationContainerCSS = (
@@ -213,7 +223,10 @@ const RevenueEquation = ({
             validateQuestionTwoAnswer()
           )}
           value={revEquationTwoBoxFour}
-          onChange={(e) => setRevEquationTwoBoxFour(e.target.value)}
+          onChange={(e) => {
+            setRevEquationTwoBoxFour(e.target.value);
+            passRevenueComponent();
+          }}
           placeholder="2"
         />
       </div>

--- a/pages/foodtruck.tsx
+++ b/pages/foodtruck.tsx
@@ -19,6 +19,8 @@ import ProfitEquation from "../components/foodtruck/ProfitEquation";
 
 import { Button } from "../components/ui/Button";
 import { EndSession } from "../components/finance/EndSession";
+import { useMutation } from "@apollo/client";
+import { UNLOCK_BADGE } from "../graphql/unlockBadge";
 
 /*
 TODO fix these issues before make it obvious when food items are not selectable
@@ -46,6 +48,18 @@ export default function FoodTruck(props) {
     SessionEnd,
   }
 
+  const disableNextStage = (stage: STAGE) => {
+    if (stage == STAGE.RevenueEquation) {
+      return !revenueComponentComplete;
+    } else if (stage == STAGE.ProdCostEquation) {
+      return !prodCostComponentComplete;
+    } else if (stage == STAGE.LaborCostEquation) {
+      return !laborCostComponentComplete;
+    } else {
+      return false;
+    }
+  };
+
   const [stage, setStage] = useState(STAGE.ChooseTruck);
 
   const previousStage = () => {
@@ -59,6 +73,8 @@ export default function FoodTruck(props) {
       setStage(stage + 1);
     }
   };
+
+  const [unlockbadge, unlockBadgeData] = useMutation(UNLOCK_BADGE);
 
   const renderWorkerImagesHTML = (n: string) => {
     return [...Array(Number.parseInt(n))].map((_, i) => (
@@ -80,6 +96,15 @@ export default function FoodTruck(props) {
   const [truck, setTruck] = useState(smallTruck);
   const [food, setFood] = useState(hotDog);
   const [selectedNumWorkers, setSelectedNumWorkers] = useState("1");
+  const [revenueComponentComplete, setRevenueComponentComplete] = useState(
+    false
+  );
+  const [prodCostComponentComplete, setProdCostComponentComplete] = useState(
+    false
+  );
+  const [laborCostComponentComplete, setLaborCostComponentComplete] = useState(
+    false
+  );
 
   // revenue equation one
   const [revEquationOneBoxOne, setRevEquationOneBoxOne] = useState("");
@@ -93,52 +118,75 @@ export default function FoodTruck(props) {
   const [revEquationTwoBoxFour, setRevEquationTwoBoxFour] = useState("");
 
   // prodCost equation one
-  const [prodCostEquationOneBoxOne, setProdCostEquationOneBoxOne] =
-    useState("");
-  const [prodCostEquationOneBoxTwo, setProdCostEquationOneBoxTwo] =
-    useState("");
-  const [prodCostEquationOneBoxThree, setProdCostEquationOneBoxThree] =
-    useState("");
+  const [prodCostEquationOneBoxOne, setProdCostEquationOneBoxOne] = useState(
+    ""
+  );
+  const [prodCostEquationOneBoxTwo, setProdCostEquationOneBoxTwo] = useState(
+    ""
+  );
+  const [
+    prodCostEquationOneBoxThree,
+    setProdCostEquationOneBoxThree,
+  ] = useState("");
 
-  const [prodCostEquationOneBoxFour, setProdCostEquationOneBoxFour] =
-    useState("");
+  const [prodCostEquationOneBoxFour, setProdCostEquationOneBoxFour] = useState(
+    ""
+  );
 
   // prodCost equation two
-  const [prodCostEquationTwoBoxOne, setProdCostEquationTwoBoxOne] =
-    useState("");
-  const [prodCostEquationTwoBoxTwo, setProdCostEquationTwoBoxTwo] =
-    useState("");
-  const [prodCostEquationTwoBoxThree, setProdCostEquationTwoBoxThree] =
-    useState("");
-  const [prodCostEquationTwoBoxFour, setProdCostEquationTwoBoxFour] =
-    useState("");
+  const [prodCostEquationTwoBoxOne, setProdCostEquationTwoBoxOne] = useState(
+    ""
+  );
+  const [prodCostEquationTwoBoxTwo, setProdCostEquationTwoBoxTwo] = useState(
+    ""
+  );
+  const [
+    prodCostEquationTwoBoxThree,
+    setProdCostEquationTwoBoxThree,
+  ] = useState("");
+  const [prodCostEquationTwoBoxFour, setProdCostEquationTwoBoxFour] = useState(
+    ""
+  );
 
   // laborCost equation one
-  const [laborCostEquationOneBoxOne, setLaborCostEquationOneBoxOne] =
-    useState("");
-  const [laborCostEquationOneBoxTwo, setLaborCostEquationOneBoxTwo] =
-    useState("");
-  const [laborCostEquationOneBoxThree, setLaborCostEquationOneBoxThree] =
-    useState("");
+  const [laborCostEquationOneBoxOne, setLaborCostEquationOneBoxOne] = useState(
+    ""
+  );
+  const [laborCostEquationOneBoxTwo, setLaborCostEquationOneBoxTwo] = useState(
+    ""
+  );
+  const [
+    laborCostEquationOneBoxThree,
+    setLaborCostEquationOneBoxThree,
+  ] = useState("");
 
-  const [laborCostEquationOneBoxFour, setLaborCostEquationOneBoxFour] =
-    useState("");
+  const [
+    laborCostEquationOneBoxFour,
+    setLaborCostEquationOneBoxFour,
+  ] = useState("");
 
   // laborCost equation two
-  const [laborCostEquationTwoBoxOne, setLaborCostEquationTwoBoxOne] =
-    useState("");
-  const [laborCostEquationTwoBoxTwo, setLaborCostEquationTwoBoxTwo] =
-    useState("");
-  const [laborCostEquationTwoBoxThree, setLaborCostEquationTwoBoxThree] =
-    useState("");
-  const [laborCostEquationTwoBoxFour, setLaborCostEquationTwoBoxFour] =
-    useState("");
+  const [laborCostEquationTwoBoxOne, setLaborCostEquationTwoBoxOne] = useState(
+    ""
+  );
+  const [laborCostEquationTwoBoxTwo, setLaborCostEquationTwoBoxTwo] = useState(
+    ""
+  );
+  const [
+    laborCostEquationTwoBoxThree,
+    setLaborCostEquationTwoBoxThree,
+  ] = useState("");
+  const [
+    laborCostEquationTwoBoxFour,
+    setLaborCostEquationTwoBoxFour,
+  ] = useState("");
 
   // profit equation one
   const [profitEquationOneBoxOne, setProfitEquationOneBoxOne] = useState("");
   const [profitEquationOneBoxTwo, setProfitEquationOneBoxTwo] = useState("");
-  const [profitEquationOneBoxThree, setProfitEquationOneBoxThree] =
-    useState("");
+  const [profitEquationOneBoxThree, setProfitEquationOneBoxThree] = useState(
+    ""
+  );
 
   const onSelectedTruckChanged = (truck: Truck) => {
     setTruck(truck);
@@ -170,6 +218,8 @@ export default function FoodTruck(props) {
         <RevenueEquation
           selectedNumWorkers={selectedNumWorkers}
           selectedFood={food}
+          revenueComponentComplete={revenueComponentComplete}
+          setRevenueComponentComplete={setRevenueComponentComplete}
           revEquationOneBoxOne={revEquationOneBoxOne}
           setRevEquationOneBoxOne={setRevEquationOneBoxOne}
           revEquationOneBoxTwo={revEquationOneBoxTwo}
@@ -191,6 +241,8 @@ export default function FoodTruck(props) {
         <ProdCostEquation
           selectedFood={food}
           selectedTruck={truck}
+          prodCostComponentComplete={prodCostComponentComplete}
+          setProdCostComponentComplete={setProdCostComponentComplete}
           selectedNumWorkers={selectedNumWorkers}
           prodCostEquationOneBoxOne={prodCostEquationOneBoxOne}
           setProdCostEquationOneBoxOne={setProdCostEquationOneBoxOne}
@@ -216,6 +268,8 @@ export default function FoodTruck(props) {
           selectedFood={food}
           selectedTruck={truck}
           selectedNumWorkers={selectedNumWorkers}
+          laborCostComponentComplete={laborCostComponentComplete}
+          setLaborCostComponentComplete={setLaborCostComponentComplete}
           laborCostEquationOneBoxOne={laborCostEquationOneBoxOne}
           setLaborCostEquationOneBoxOne={setLaborCostEquationOneBoxOne}
           laborCostEquationOneBoxTwo={laborCostEquationOneBoxTwo}
@@ -413,17 +467,24 @@ export default function FoodTruck(props) {
             textColor="white"
             label="Next"
             onClick={nextStage}
+            disabled={disableNextStage(stage)}
           />
         </div>
       </div>
       {stage === STAGE.SessionEnd ? (
-        <EndSession onClick={() => {setStage(STAGE.ChooseTruck)}} />
+        <EndSession
+          onClick={() => {
+            setStage(STAGE.ChooseTruck);
+          }}
+        />
       ) : (
         <div className="flex-grow grid grid-cols-12">
           <div className="col-span-8 overflow-y-auto bg-blue-100">
             {getLeftComponent(stage)}
           </div>
-          <div className="col-span-4 bg-purple-200 h-full">{getProgressComponent(stage)}</div>
+          <div className="col-span-4 bg-purple-200 h-full">
+            {getProgressComponent(stage)}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
added new state variables / callback functions to revenue and cost equation components to communicate to parent whether the component has been successfully completed; then feed these callback functions into a helper function which is passed into the disabled flag for the Next button

There is some sort of issue I have not been able to fully debug though:

on initial state of the revenue equation, the UI is correct and the button is disabled: 

<img width="1405" alt="Screen Shot 2021-10-20 at 6 40 00 PM" src="https://user-images.githubusercontent.com/66029765/138182382-afe1f488-684a-4a5d-90c5-beb9564ba663.png">

when I complete the equations, the button is still disabled: 
<img width="704" alt="Screen Shot 2021-10-20 at 6 41 08 PM" src="https://user-images.githubusercontent.com/66029765/138182499-64b4a894-8457-433e-b0b0-cf67a345dcb7.png">

if I erase one character, the button somehow enables but the answer is then incorrect:
<img width="690" alt="Screen Shot 2021-10-20 at 6 42 02 PM" src="https://user-images.githubusercontent.com/66029765/138182573-336c3026-1c33-43e7-84c4-9ba6e10985de.png">



