### PR TITLE
Create a Layout component 

### DIFF
--- a/components/coding/studentPortal/Layout.tsx
+++ b/components/coding/studentPortal/Layout.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export const Layout: React.FC = ({ children }) => {
+  return (
+    <div className="grid grid-cols-12">
+      <div className="hidden lg:flex col-span-2">LEFT</div>
+      <div className="grid grid-cols-1 col-span-12 lg:col-span-10 gap-4 bg-white shadow-lg p-8">
+        <main>{children}</main>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/components/coding/studentPortal/Layout.tsx
+++ b/components/coding/studentPortal/Layout.tsx
@@ -1,9 +1,12 @@
 import React from "react";
+import Sidebar from "./Sidebar";
 
 export const Layout: React.FC = ({ children }) => {
   return (
     <div className="grid grid-cols-12">
-      <div className="hidden lg:flex col-span-2">LEFT</div>
+      <div className="hidden lg:flex col-span-2">
+        <Sidebar />
+      </div>
       <div className="grid grid-cols-1 col-span-12 lg:col-span-10 gap-4 bg-white shadow-lg p-8">
         <main>{children}</main>
       </div>

--- a/components/coding/studentPortal/Sidebar.tsx
+++ b/components/coding/studentPortal/Sidebar.tsx
@@ -18,21 +18,22 @@ export const Sidebar: React.FC<SidebarProps> = ({}: SidebarProps) => {
               <p className="font-medium ml-4">Student</p>
             </div>
           </div>
-          <div className={`"border-charmander text-charmander"`}>
-            <div className={`p-4 border-l-4 border-charmander text-charmander`}>
-              <div className="flex flex-wrap">
-                <img
-                  className="w-8 h-8 mr-4"
-                  src="/images/dashBoardActive.svg"
-                />
-                Dashboard
+          <a className={``} href="/studentPortal">
+            <div className={`"border-charmander text-charmander"`}>
+              <div
+                className={`p-4 border-l-4 border-charmander text-charmander`}
+              >
+                <div className="flex flex-wrap">
+                  <img
+                    className="w-8 h-8 mr-4"
+                    src="/images/dashBoardActive.svg"
+                  />
+                  Dashboard
+                </div>
               </div>
             </div>
-          </div>
-          <a
-            className={`p-4 border-l-4`}
-            href="https://www.skillify.ca/profile"
-          >
+          </a>
+          <a className={`p-4 border-l-4`} href="/math/profile">
             <div className="flex flex-wrap">
               <img
                 className="w-8 h-8 mr-4"
@@ -45,7 +46,7 @@ export const Sidebar: React.FC<SidebarProps> = ({}: SidebarProps) => {
           <a
             className={`p-4 border-l-4
             `}
-            href="https://www.skillify.ca/profile"
+            href="/math/profile"
           >
             <div className="flex flex-wrap">
               <img className="w-8 h-8 mr-4" src="/images/profileInactive.svg" />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -51,8 +51,7 @@ function MyApp({ Component, pageProps: { ...pageProps } }) {
             <AuthProvider>
               {Component.auth ? (
                 <Auth>
-                  <Navbar/>
-                  getLayout(<Component {...pageProps} />)
+                  {getLayout(<Component {...pageProps} />)}
                 </Auth>
               ) : (
                 getLayout(<Component {...pageProps} />)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,6 +37,9 @@ function MyApp({ Component, pageProps: { ...pageProps } }) {
     isMobile = window.innerWidth < 600;
   }
 
+  // Use the layout defined at the page level, if available
+  const getLayout = Component.getLayout || ((page) => page)
+
   // TODO remove setting Component.Auth
   return (
     <ApolloProvider client={client}>
@@ -49,10 +52,10 @@ function MyApp({ Component, pageProps: { ...pageProps } }) {
               {Component.auth ? (
                 <Auth>
                   <Navbar/>
-                  <Component {...pageProps} />
+                  getLayout(<Component {...pageProps} />)
                 </Auth>
               ) : (
-                <Component {...pageProps} />
+                getLayout(<Component {...pageProps} />)
               )}
             </AuthProvider>
           </ReduxProvider>

--- a/pages/math/profile.tsx
+++ b/pages/math/profile.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import React from "react";
 import { Leaderboard } from "../../components/coding/Leaderboard";
+import Layout from "../../components/coding/studentPortal/Layout";
 import ProfileComponent from "../../components/ProfileComponent";
 
 const Profile = () => {
@@ -18,3 +19,7 @@ const Profile = () => {
 export default Profile;
 
 Profile.auth = true;
+
+Profile.getLayout = function getLayout(page) {
+  return <Layout>{page}</Layout>;
+};

--- a/pages/studentPortal.tsx
+++ b/pages/studentPortal.tsx
@@ -1,24 +1,23 @@
 import React from "react";
+import Layout from "../components/coding/studentPortal/Layout";
 import Sidebar from "../components/coding/studentPortal/Sidebar";
 import UnitView from "../components/coding/studentPortal/UnitView";
 import units from "./api/studentPortal/units";
 
 export default function StudentPortalPage() {
   return (
-    <div className="grid grid-cols-12">
-      <div className="hidden lg:flex col-span-2">LEFT</div>
-      <div className="grid grid-cols-1 col-span-12 lg:col-span-7 gap-4 bg-white shadow-lg p-8">
-        <p>Today's Date</p>
-        <p>Let's start learning, David</p>
-        <div className="grid grid-cols-1 gap-4">
-          {units.map((it) => (
-            <UnitView data={it} />
-          ))}
-        </div>
+    <>
+      <p>Today's Date</p>
+      <p>Let's start learning, David</p>
+      <div className="grid grid-cols-1 gap-4">
+        {units.map((it) => (
+          <UnitView data={it} />
+        ))}
       </div>
-      <div className="hidden lg:flex col-span-3">
-        <Sidebar />
-      </div>
-    </div>
+    </>
   );
 }
+
+StudentPortalPage.getLayout = function getLayout(page) {
+  return <Layout>{page}</Layout>;
+};


### PR DESCRIPTION
This PR creates a new Layout component that will be used in the student portal page. I followed the documentation here: https://nextjs.org/docs/basic-features/layouts

Instead of adding a sidebar to every page, Next.js will just have one sidebar that will retain state as the user clicks on different pages. That means if you add an internal state to your sidebar component for determining which menu item should be considered active, then nextjs will preserve that state as you navigate to other pages.

<img width="1440" alt="Screen Shot 2022-03-09 at 8 30 18 PM" src="https://user-images.githubusercontent.com/4795012/157569263-80255b20-193e-4efc-90b8-5e679faa0d14.png">
