### PR TITLE
Ignore build errors on production using next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    typescript: {
+      // !! WARN !!
+      // Dangerously allow production builds to successfully complete even if
+      // your project has type errors.
+      // !! WARN !!
+      ignoreBuildErrors: true,
+    },
+  }


### PR DESCRIPTION
Builds were failing on Vercel. Looks like there was an issue reported here: https://github.com/vercel/next.js/issues/36019#issuecomment-1094122456

We'll ignore errors for now until Vercel fixes the issue on their end. This will unblock us from merging in PRs for now.