### PR TITLE
Remove a tag links

### DIFF
--- a/components/coding/studentPortal/quiz/Quiz.tsx
+++ b/components/coding/studentPortal/quiz/Quiz.tsx
@@ -67,10 +67,10 @@ export default function Quiz({}: QuizProps) {
             <p className="text-2xl">{questions[currentQuestion].text}</p>
           </div>
           {questions[currentQuestion].image ? (
-            <div className="flex flew-row w-full justify-around">
+            <div className="flex justify-around w-full px-8 pb-8 flew-row">
               <img
                 src={questions[currentQuestion].image}
-                className="max-h-72 justify-around"
+                className="justify-around max-h-72"
               />
             </div>
           ) : (

--- a/pages/studentPortal/intro/CSS/6.tsx
+++ b/pages/studentPortal/intro/CSS/6.tsx
@@ -39,12 +39,12 @@ const CSS6 = ({ lessonComponents }) => {
   return (
     <>
       <div className="col-span-7">
-        <div className="grid h-full grid-cols-1 p-8 space-y-4 bg-gray-100 text-gray-700">
+        <div className="grid h-full grid-cols-1 p-8 space-y-4 text-gray-700 bg-gray-100">
           <ProgressBar completed={100} />
           {lessonComponents.map((it) => (
             <LessonComponent data={it} />
           ))}
-          <h1 className="font-bold text-xl mt-12">How to get started:</h1>
+          <h1 className="mt-12 text-xl font-bold">How to get started:</h1>
           <div className="flex-row">
             <h1 className="text-charmander">Step 1:</h1>
             <p>
@@ -77,13 +77,11 @@ const CSS6 = ({ lessonComponents }) => {
             </p>
           </div>
           <div className="flex h-full mt-16 sm:justify-end">
-            <a href={"/studentPortal/intro"}>
-              <Button
-                label="Continue"
-                disabled={false}
-                onClick={handleContinue}
-              />
-            </a>
+            <Button
+              label="Continue"
+              disabled={false}
+              onClick={handleContinue}
+            />
           </div>
         </div>
       </div>

--- a/pages/studentPortal/intro/CSS/css-quiz.tsx
+++ b/pages/studentPortal/intro/CSS/css-quiz.tsx
@@ -106,13 +106,11 @@ const CSS_QUIZ = () => {
         <div className="w-full p-8 h-36 ">
           <div className="flex justify-end w-full">
             {showSessionEnd ? (
-              <Link href="/studentPortal/intro/CSS/5">
-                <Button
-                  label="Continue"
-                  disabled={false}
-                  onClick={handleContinue}
-                />
-              </Link>
+              <Button
+                label="Continue"
+                disabled={false}
+                onClick={handleContinue}
+              />
             ) : (
               <Button
                 label="Continue"


### PR DESCRIPTION
we already call router.push so there's no need for a tags here. in some places the href of the a tag was different from the destination in router.push. We can remove the inconsistency by only using router.push