### PR TITLE
create base HTML template for goals page and goals data structure 

### DIFF
--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -132,68 +132,6 @@ export default function Goals(props) {
           </div>
         );
       })}
-
-      <div>
-        <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
-          Current Goals
-        </h2>
-        <div className="grid grid-cols-12 text-center">
-          <p className="col-span-1 font-bold">#</p>
-          <p className="col-span-5 font-bold">Goal Name</p>
-          <p className="col-span-2 font-bold">Date Added</p>
-          <p className="col-span-2 font-bold">Target Completion</p>
-          <p className="col-span-2"></p>
-          <p className="col-span-1">1</p>
-          <p className="col-span-5">Learn React Fundeamentals</p>
-          <p className="col-span-2">2022-06-01</p>
-          <p className="col-span-2">2022-06-14</p>
-          <div className="col-span-2 flex justify-center">
-            <CheckCircleIcon className="h-5 w-5" />
-            <ArchiveIcon className="h-5 w-5" />
-          </div>
-        </div>
-      </div>
-      <div>
-        <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
-          Completed Goals
-        </h2>
-        <div className="grid grid-cols-12 text-center">
-          <p className="col-span-1 font-bold">#</p>
-          <p className="col-span-5 font-bold">Goal Name</p>
-          <p className="col-span-2 font-bold">Date Added</p>
-          <p className="col-span-2 font-bold">Target Completion</p>
-          <p className="col-span-2"></p>
-          <p className="col-span-1">1</p>
-          <p className="col-span-5">Learn React Fundeamentals</p>
-          <p className="col-span-2">2022-06-01</p>
-          <p className="col-span-2">2022-06-14</p>
-          <div className="col-span-2 flex justify-center">
-            <ArchiveIcon className="h-5 w-5" />
-            <TrashIcon className="h-5 w-5" />
-            <CheckCircleIcon className="h-5 w-5" />
-          </div>
-        </div>
-      </div>
-      <div>
-        <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
-          Archived Goals
-        </h2>
-        <div className="grid grid-cols-12 text-center">
-          <p className="col-span-1 font-bold">#</p>
-          <p className="col-span-5 font-bold">Goal Name</p>
-          <p className="col-span-2 font-bold">Date Added</p>
-          <p className="col-span-2 font-bold">Target Completion</p>
-          <p className="col-span-2"></p>
-          <p className="col-span-1">1</p>
-          <p className="col-span-5">Learn React Fundeamentals</p>
-          <p className="col-span-2">2022-06-01</p>
-          <p className="col-span-2">2022-06-14</p>
-          <div className="col-span-2 flex justify-center">
-            <ArchiveIcon className="h-5 w-5" />
-            <TrashIcon className="h-5 w-5" />
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+
+import { useAuth } from "../lib/authContext";
+
+export default function Goals(props) {
+  const { user } = useAuth();
+
+  return (
+    <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
+      <div>
+        <h2 className="mt-14 mb-9 font-bold text-lg">Current Goals</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 mb-16"></div>
+      </div>
+      <div>
+        <h2 className="mt-14 mb-9 font-bold text-lg">Completed Goals</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 mb-16"></div>
+      </div>
+      <div>
+        <h2 className="mt-14 mb-9 font-bold text-lg">Archived Goals</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 mb-16"></div>
+      </div>
+    </div>
+  );
+}
+
+Goals.auth = true;

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -114,16 +114,16 @@ export default function Goals(props) {
               <p className="col-span-2 font-bold">Target Completion</p>
               <p className="col-span-2"></p>
             </div>
-            {section.rows.map((goal) => {
+            {section.rows.map((goal, index) => {
               return (
                 <div className="grid grid-cols-12 text-center">
-                  <p className="col-span-1">1</p>
+                  <p className="col-span-1">{index + 1}</p>
                   <p className="col-span-5">{goal.goalName}</p>
                   <p className="col-span-2">{goal.createdDate}</p>
                   <p className="col-span-2">{goal.targetDate}</p>
                   <div className="col-span-2 flex justify-center">
                     {section.header.manageIcons.map((icon) => {
-                      return <React.Fragment>{icon}</React.Fragment>;
+                      return <div>{icon}</div>;
                     })}
                   </div>
                 </div>

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -1,23 +1,198 @@
 import React, { useState } from "react";
 
 import { useAuth } from "../lib/authContext";
+import {
+  ArchiveIcon,
+  TrashIcon,
+  CheckCircleIcon,
+} from "@heroicons/react/solid";
 
 export default function Goals(props) {
   const { user } = useAuth();
 
+  // need to define types for GoalsSections Data
+
+  // sample data for Goals Sections, eventually pull from hasura and map to this data structure
+
+  const tailwindIconSize = "h-5 w-5";
+
+  const GoalsSections = [
+    {
+      header: {
+        sectionName: "Current Goals",
+        // array of heroicon components
+        manageIcons: [
+          <ArchiveIcon className={tailwindIconSize} />,
+          <TrashIcon className={tailwindIconSize} />,
+          <CheckCircleIcon className={tailwindIconSize} />,
+        ],
+      },
+      rows: [
+        {
+          goalName: "Learn React Fundamentals",
+          createdDate: "2022-06-01",
+          targetDate: "2022-06-14",
+        },
+        {
+          goalName: "First 5 problems of LeetCode 75",
+          createdDate: "2022-06-01",
+          targetDate: "2022-06-07",
+        },
+        {
+          goalName: "Lorem Ipsum Dolor Sit Amet",
+          createdDate: "2022-06-07",
+          targetDate: "2022-07-01",
+        },
+      ],
+    },
+
+    {
+      header: {
+        sectionName: "Completed Goals",
+        // array of heroicon components
+        manageIcons: [
+          <ArchiveIcon className={tailwindIconSize} />,
+          <TrashIcon className={tailwindIconSize} />,
+        ],
+      },
+      rows: [
+        {
+          goalName: "Complete all levels of FlexBox Frog Game",
+          createdDate: "2022-06-01",
+          targetDate: "2022-06-08",
+        },
+        {
+          goalName: "Build Basic HTML page",
+          createdDate: "2022-06-01",
+          targetDate: "2022-06-06",
+        },
+        {
+          goalName: "Make first pull request",
+          createdDate: "2022-06-01",
+          targetDate: "2022-06-02",
+        },
+      ],
+    },
+
+    {
+      header: {
+        sectionName: "Archived Goals",
+        // array of heroicon components
+        manageIcons: [
+          <ArchiveIcon className={tailwindIconSize} />,
+          <TrashIcon className={tailwindIconSize} />,
+          <CheckCircleIcon className={tailwindIconSize} />,
+        ],
+      },
+      rows: [
+        {
+          goalName: "Learn Kotlin",
+          createdDate: "2022-06-01",
+          targetDate: "2022-09-01",
+        },
+        {
+          goalName: "Learn SQL",
+          createdDate: "2022-06-01",
+          targetDate: "2022-09-01",
+        },
+      ],
+    },
+  ];
+
   return (
     <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
+      {GoalsSections.map((section) => {
+        return (
+          <div>
+            <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
+              {section.header.sectionName}
+            </h2>
+            <div className="grid grid-cols-12 text-center">
+              <p className="col-span-1 font-bold">#</p>
+              <p className="col-span-5 font-bold">Goal Name</p>
+              <p className="col-span-2 font-bold">Date Added</p>
+              <p className="col-span-2 font-bold">Target Completion</p>
+              <p className="col-span-2"></p>
+            </div>
+            {section.rows.map((goal) => {
+              return (
+                <div className="grid grid-cols-12 text-center">
+                  <p className="col-span-1">1</p>
+                  <p className="col-span-5">{goal.goalName}</p>
+                  <p className="col-span-2">{goal.createdDate}</p>
+                  <p className="col-span-2">{goal.targetDate}</p>
+                  <div className="col-span-2 flex justify-center">
+                    {section.header.manageIcons.map((icon) => {
+                      return <React.Fragment>{icon}</React.Fragment>;
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+
       <div>
-        <h2 className="mt-14 mb-9 font-bold text-lg">Current Goals</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-3 mb-16"></div>
+        <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
+          Current Goals
+        </h2>
+        <div className="grid grid-cols-12 text-center">
+          <p className="col-span-1 font-bold">#</p>
+          <p className="col-span-5 font-bold">Goal Name</p>
+          <p className="col-span-2 font-bold">Date Added</p>
+          <p className="col-span-2 font-bold">Target Completion</p>
+          <p className="col-span-2"></p>
+          <p className="col-span-1">1</p>
+          <p className="col-span-5">Learn React Fundeamentals</p>
+          <p className="col-span-2">2022-06-01</p>
+          <p className="col-span-2">2022-06-14</p>
+          <div className="col-span-2 flex justify-center">
+            <CheckCircleIcon className="h-5 w-5" />
+            <ArchiveIcon className="h-5 w-5" />
+          </div>
+        </div>
       </div>
       <div>
-        <h2 className="mt-14 mb-9 font-bold text-lg">Completed Goals</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-3 mb-16"></div>
+        <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
+          Completed Goals
+        </h2>
+        <div className="grid grid-cols-12 text-center">
+          <p className="col-span-1 font-bold">#</p>
+          <p className="col-span-5 font-bold">Goal Name</p>
+          <p className="col-span-2 font-bold">Date Added</p>
+          <p className="col-span-2 font-bold">Target Completion</p>
+          <p className="col-span-2"></p>
+          <p className="col-span-1">1</p>
+          <p className="col-span-5">Learn React Fundeamentals</p>
+          <p className="col-span-2">2022-06-01</p>
+          <p className="col-span-2">2022-06-14</p>
+          <div className="col-span-2 flex justify-center">
+            <ArchiveIcon className="h-5 w-5" />
+            <TrashIcon className="h-5 w-5" />
+            <CheckCircleIcon className="h-5 w-5" />
+          </div>
+        </div>
       </div>
       <div>
-        <h2 className="mt-14 mb-9 font-bold text-lg">Archived Goals</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-3 mb-16"></div>
+        <h2 className="mt-14 mb-9 font-bold text-lg border-b-2">
+          Archived Goals
+        </h2>
+        <div className="grid grid-cols-12 text-center">
+          <p className="col-span-1 font-bold">#</p>
+          <p className="col-span-5 font-bold">Goal Name</p>
+          <p className="col-span-2 font-bold">Date Added</p>
+          <p className="col-span-2 font-bold">Target Completion</p>
+          <p className="col-span-2"></p>
+          <p className="col-span-1">1</p>
+          <p className="col-span-5">Learn React Fundeamentals</p>
+          <p className="col-span-2">2022-06-01</p>
+          <p className="col-span-2">2022-06-14</p>
+          <div className="col-span-2 flex justify-center">
+            <ArchiveIcon className="h-5 w-5" />
+            <TrashIcon className="h-5 w-5" />
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- created a template for how the goals will be rendered based on the designs I shared earlier
- created a data structure to hold each section and its goals, and sample data in the GoalsSection variable; idea is that the sample data will be replaced by hasura response and transformed into this data structure
- render the sample data through a series of maps - trying to make this clean and repeatable

lmk what you think of this data structure and approach. I think what I'm going for is having one standardized Goal section component, then passing the hasura response as a prop into this component following the data structure I started defining... 

<img width="1467" alt="Screen Shot 2022-06-27 at 4 52 06 PM" src="https://user-images.githubusercontent.com/98791180/176033539-b64deab7-4df2-4ee1-9317-d06d1d469267.png">
 