### PR TITLE
create edit goals form

### DIFF
--- a/graphql/upsertUserGoals.ts
+++ b/graphql/upsertUserGoals.ts
@@ -1,0 +1,36 @@
+import { gql } from "@apollo/client";
+
+// updates goal with new values in $objects if existing id is provided; inserts new goal if no ID provided
+// userId in objects must exist in users table; if id is provided, it must exist in goals table
+
+export const UPSERT_USER_GOALS = gql`
+  mutation upsertUserGoals($objects: [user_goals_insert_input!]!) {
+    insert_user_goals(
+      objects: $objects
+      on_conflict: {
+        constraint: user_goals_pkey
+        update_columns: [
+          goalName
+          isArchived
+          isComplete
+          isActive
+          updatedAt
+          targetDate
+        ]
+      }
+    ) {
+      affected_rows
+      returning {
+        id
+        goalName
+        isActive
+        isArchived
+        isComplete
+        targetDate
+        updatedAt
+        userId
+        createdAt
+      }
+    }
+  }
+`;

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -122,9 +122,20 @@ const EditGoalsPage = () => {
             <Button
               label="Save"
               onClick={() => {
+                // this is a workaround to remove __typename from the gql response which causes mutation to fail
+                const removeTypeNameForHasura = {
+                  goalName: editedGoalValues.goalName,
+                  userId: editedGoalValues.userId,
+                  id: editedGoalValues.id,
+                  isArchived: editedGoalValues.isArchived,
+                  isComplete: editedGoalValues.isComplete,
+                  targetDate: editedGoalValues.targetDate,
+                  isActive: editedGoalValues.isActive,
+                };
+
                 saveEditedGoals({
                   variables: {
-                    objects: editedGoalValues,
+                    objects: removeTypeNameForHasura,
                   },
                 });
               }}

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -14,6 +14,8 @@ import {
   UserGoalsData,
 } from "../../graphql/fetchUserGoals";
 import { useAuth } from "../../lib/authContext";
+import { useMutation } from "@apollo/client";
+import { UPSERT_USER_GOALS } from "../../graphql/upsertUserGoals";
 
 const EditGoalsPage = () => {
   const { user } = useAuth();
@@ -22,6 +24,8 @@ const EditGoalsPage = () => {
   const { slug } = router.query;
 
   const [editedGoalValues, setEditedGoalValues] = useState<UserGoalsData>();
+
+  const [saveEditedGoals] = useMutation(UPSERT_USER_GOALS);
 
   const goalDetailResults = useQuery<FetchUserGoalsDataResponse>(
     FETCH_USER_GOAL_DETAIL,
@@ -115,7 +119,16 @@ const EditGoalsPage = () => {
                 }))
               }
             />
-            <Button label="Save" />
+            <Button
+              label="Save"
+              onClick={() => {
+                saveEditedGoals({
+                  variables: {
+                    objects: editedGoalValues,
+                  },
+                });
+              }}
+            />
           </div>
         </div>
       )}

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -25,7 +25,9 @@ const EditGoalsPage = () => {
 
   const [editedGoalValues, setEditedGoalValues] = useState<UserGoalsData>();
 
-  const [saveEditedGoals] = useMutation(UPSERT_USER_GOALS);
+  const [saveEditedGoals] = useMutation(UPSERT_USER_GOALS, {
+    onCompleted: () => router.push("/goals"),
+  });
 
   const goalDetailResults = useQuery<FetchUserGoalsDataResponse>(
     FETCH_USER_GOAL_DETAIL,

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -3,7 +3,7 @@ import {
   ArchiveIcon,
   CheckCircleIcon,
   TrashIcon,
-} from "@heroicons/react/outline";
+} from "@heroicons/react/solid";
 import { format } from "date-fns";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
@@ -85,11 +85,12 @@ const EditGoalsPage = () => {
               disabled
             />
           </div>
-          <div className="flex flex-row mt-8 space-x-4">
+          <div className="grid grid-cols-12 items-center mt-8">
+            <p className="text-center font-bold">Archive Goal</p>
             <ArchiveIcon
               className={
-                "h-10 w-10" + goalDetail.isArchived
-                  ? "text-yellow-600 h-10 w-10"
+                editedGoalValues.isArchived
+                  ? "h-10 w-10 text-yellow-600"
                   : "h-10 w-10"
               }
               onClick={() =>
@@ -99,10 +100,13 @@ const EditGoalsPage = () => {
                 }))
               }
             />
-            <TrashIcon className="h-10 w-10" />
+
+            <p className="text-center font-bold">Complete Goal</p>
             <CheckCircleIcon
               className={
-                goalDetail.isComplete ? "h-10 w-10 text-green-600" : "h-10 w-10"
+                editedGoalValues.isComplete
+                  ? "h-10 w-10 text-green-600"
+                  : "h-10 w-10"
               }
               onClick={() =>
                 setEditedGoalValues((prevState) => ({

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -21,12 +21,17 @@ const EditGoalsPage = () => {
   const router = useRouter();
   const { slug } = router.query;
 
+  const [editedGoalValues, setEditedGoalValues] = useState<UserGoalsData>();
+
   const goalDetailResults = useQuery<FetchUserGoalsDataResponse>(
     FETCH_USER_GOAL_DETAIL,
     {
       variables: {
         userId: user.uid,
         id: slug,
+      },
+      onCompleted: (data) => {
+        setEditedGoalValues(data.user_goals[0]);
       },
     }
   );
@@ -39,7 +44,7 @@ const EditGoalsPage = () => {
   return (
     <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
       <h1 className="text-3xl font-bold mb-4">Edit Goal</h1>
-      {goalDetail && (
+      {goalDetail && editedGoalValues && (
         <div>
           <div className="flex flex-col space-y-2">
             <p className="font-bold">Goal Name</p>
@@ -47,6 +52,13 @@ const EditGoalsPage = () => {
               type="text"
               className="text-left p-2 border rounded-md shadow-md w-1/2"
               placeholder={goalDetail.goalName}
+              value={editedGoalValues.goalName}
+              onChange={(e) => {
+                setEditedGoalValues((prevState) => ({
+                  ...prevState,
+                  goalName: e.target.value,
+                }));
+              }}
             />
             <p className="font-bold">Created On</p>
             <input
@@ -80,16 +92,23 @@ const EditGoalsPage = () => {
                   ? "text-yellow-600 h-10 w-10"
                   : "h-10 w-10"
               }
-            />
-            <TrashIcon
-              className={
-                goalDetail.isComplete ? "h-10 w-10 text-red-600" : "h-10 w-10"
+              onClick={() =>
+                setEditedGoalValues((prevState) => ({
+                  ...prevState,
+                  isArchived: !prevState.isArchived,
+                }))
               }
-              path="text-"
             />
+            <TrashIcon className="h-10 w-10" />
             <CheckCircleIcon
               className={
                 goalDetail.isComplete ? "h-10 w-10 text-green-600" : "h-10 w-10"
+              }
+              onClick={() =>
+                setEditedGoalValues((prevState) => ({
+                  ...prevState,
+                  isComplete: !prevState.isComplete,
+                }))
               }
             />
             <Button label="Save" />

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -74,9 +74,24 @@ const EditGoalsPage = () => {
             />
           </div>
           <div className="flex flex-row mt-8 space-x-4">
-            <ArchiveIcon className="h-10 w-10" />
-            <TrashIcon className="h-10 w-10" />
-            <CheckCircleIcon className="h-10 w-10" />
+            <ArchiveIcon
+              className={
+                "h-10 w-10" + goalDetail.isArchived
+                  ? "text-yellow-600 h-10 w-10"
+                  : "h-10 w-10"
+              }
+            />
+            <TrashIcon
+              className={
+                goalDetail.isComplete ? "h-10 w-10 text-red-600" : "h-10 w-10"
+              }
+              path="text-"
+            />
+            <CheckCircleIcon
+              className={
+                goalDetail.isComplete ? "h-10 w-10 text-green-600" : "h-10 w-10"
+              }
+            />
             <Button label="Save" />
           </div>
         </div>

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -123,6 +123,7 @@ const EditGoalsPage = () => {
             />
             <Button
               label="Save"
+              disabled={goalDetail === editedGoalValues}
               onClick={() => {
                 // this is a workaround to remove __typename from the gql response which causes mutation to fail
                 const removeTypeNameForHasura = {

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -1,5 +1,9 @@
 import { useQuery } from "@apollo/client";
-import { ArchiveIcon, TrashIcon } from "@heroicons/react/outline";
+import {
+  ArchiveIcon,
+  CheckCircleIcon,
+  TrashIcon,
+} from "@heroicons/react/outline";
 import { format } from "date-fns";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
@@ -72,6 +76,7 @@ const EditGoalsPage = () => {
           <div className="flex flex-row mt-8 space-x-4">
             <ArchiveIcon className="h-10 w-10" />
             <TrashIcon className="h-10 w-10" />
+            <CheckCircleIcon className="h-10 w-10" />
             <Button label="Save" />
           </div>
         </div>
@@ -81,22 +86,3 @@ const EditGoalsPage = () => {
 };
 
 export default EditGoalsPage;
-
-{
-  /* <p className="col-span-2">Goal Name:</p>
-          <p className="col-span-2">{goalDetail.goalName}</p>
-          <p className="col-start-1 col-span-2">Target Completion:</p>
-          <p className="col-span-2">
-            {goalDetail.targetDate ?? "No Target Date Set"}
-          </p>
-          <p className="col-start-1 col-span-2">Created Date:</p>
-          <p className="col-span-2">
-            {format(new Date(goalDetail.targetDate), "MMMM dd yyyy")}
-          </p>
-          <p className="col-start-1 col-span-2">Is Goal Active?</p>
-          <p className="col-span-2">{goalDetail.isActive ? "Yes" : "No"}</p>
-          <p className="col-start-1 col-span-2">Is Goal Complete?</p>
-          <p className="col-span-2">{goalDetail.isComplete ? "Yes" : "No"}</p>
-          <p className="col-start-1 col-span-2">Is Goal Archived?</p>
-          <p className="col-span-2">{goalDetail.isArchived ? "Yes" : "No"}</p> */
-}

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -1,7 +1,9 @@
 import { useQuery } from "@apollo/client";
+import { ArchiveIcon, TrashIcon } from "@heroicons/react/outline";
 import { format } from "date-fns";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
+import { Button } from "../../components/ui/Button";
 import {
   FetchUserGoalsDataResponse,
   FETCH_USER_GOAL_DETAIL,
@@ -34,8 +36,54 @@ const EditGoalsPage = () => {
     <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
       <h1 className="text-3xl font-bold mb-4">Edit Goal</h1>
       {goalDetail && (
-        <div className="grid grid-cols-12">
-          <p className="col-span-2">Goal Name:</p>
+        <div>
+          <div className="flex flex-col space-y-2">
+            <p className="font-bold">Goal Name</p>
+            <input
+              type="text"
+              className="text-left p-2 border rounded-md shadow-md w-1/2"
+              placeholder={goalDetail.goalName}
+            />
+            <p className="font-bold">Created On</p>
+            <input
+              type="text"
+              className="text-left p-2 border rounded-md shadow-md w-1/4"
+              value={format(new Date(goalDetail.createdAt), "MMMM dd yyyy")}
+              disabled
+            />
+            <p className="font-bold">Last Updated</p>
+            <input
+              type="text"
+              className="text-left p-2 border rounded-md shadow-md w-1/4"
+              value={format(new Date(goalDetail.updatedAt), "MMMM dd yyyy")}
+              disabled
+            />
+            <p className="font-bold">Target Completion Date</p>
+            <input
+              type="text"
+              className="text-left p-2 border rounded-md shadow-md w-1/4"
+              value={
+                format(new Date(goalDetail.targetDate), "MMMM dd yyyy") ??
+                "No Date Set"
+              }
+              disabled
+            />
+          </div>
+          <div className="flex flex-row mt-8 space-x-4">
+            <ArchiveIcon className="h-10 w-10" />
+            <TrashIcon className="h-10 w-10" />
+            <Button label="Save" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EditGoalsPage;
+
+{
+  /* <p className="col-span-2">Goal Name:</p>
           <p className="col-span-2">{goalDetail.goalName}</p>
           <p className="col-start-1 col-span-2">Target Completion:</p>
           <p className="col-span-2">
@@ -50,11 +98,5 @@ const EditGoalsPage = () => {
           <p className="col-start-1 col-span-2">Is Goal Complete?</p>
           <p className="col-span-2">{goalDetail.isComplete ? "Yes" : "No"}</p>
           <p className="col-start-1 col-span-2">Is Goal Archived?</p>
-          <p className="col-span-2">{goalDetail.isArchived ? "Yes" : "No"}</p>
-        </div>
-      )}
-    </div>
-  );
-};
-
-export default EditGoalsPage;
+          <p className="col-span-2">{goalDetail.isArchived ? "Yes" : "No"}</p> */
+}


### PR DESCRIPTION
Created an edit goal form on the slug page... on entering this page from the goals page, a user can now:
- change the goal name 
- archive / unarchive a goal by clicking on the archive icon; when colored yellow, the goal is archived vice versa
- complete / uncomplete a goal by clicking on the check mark icon; when colored green, the goal is completed vice versa
- save the edited goal to Hasura and get navigated back to the main goals page where the changes are in effect

I ran into a weird issue passing the edited goals to Hasura - the goal detail object had a "__typename" appended to the response even though it wasn't defined in the type. The one way I was able to get around this was creating a typeless copy of the object before passing it into the mutation. Seems like other people have ran into this [issue](https://github.com/apollographql/apollo-client/issues/1564)

Other notes:
- don't think the isActive column makes sense so I'll be removing that in the next iteration
- will add the date picker next, decided to hold off since I ran into the mutation issue and this PR is already getting kind of long

UI screenshot:
<img width="726" alt="Screen Shot 2022-07-05 at 3 53 46 PM" src="https://user-images.githubusercontent.com/98791180/177430063-529e5c22-d522-4dd9-8682-d9af4ada18b8.png">
 