### PR TITLE
add date picker for setting goal target; UI changes to goals overview

### DIFF
--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -17,23 +17,25 @@ export default function GoalsSection({
     <div>
       <h2 className="mt-4 mb-4 font-bold text-lg border-b-2">{sectionName}</h2>
 
-      <div className="grid grid-cols-12 text-center">
-        <p className="col-span-1 font-bold">#</p>
-        <p className="col-span-5 font-bold">Goal Name</p>
-        <p className="col-span-2 font-bold">Date Added</p>
-        <p className="col-span-2 font-bold">Target Completion</p>
-        <p className="col-span-2"></p>
-      </div>
+      {sectionName == "Current Goals" && (
+        <div className="grid grid-cols-12 text-center">
+          <p className="col-start-2 col-span-5 font-bold">Goal Name</p>
+          <p className="col-span-2 font-bold">Date Added</p>
+          <p className="col-span-2 font-bold">Target Completion</p>
+          <p className="col-span-2"></p>
+        </div>
+      )}
+
       {userGoals.map((goal, index) => {
         return (
           <div className="grid grid-cols-12 text-center">
             <p className="col-span-1">{index + 1}</p>
             <p className="col-span-5">{goal.goalName}</p>
             <p className="col-span-2">
-              {format(new Date(goal.createdAt), "MMMM yyyy")}
+              {format(new Date(goal.createdAt), "MM/dd/yyyy")}
             </p>
             <p className="col-span-2">
-              {format(new Date(goal.targetDate), "MMMM yyyy")}
+              {format(new Date(goal.targetDate), "MM/dd/yyyy")}
             </p>
             <div>
               <Link href={"/goals/" + goal.id}>

--- a/pages/goals.tsx
+++ b/pages/goals.tsx
@@ -9,6 +9,7 @@ import {
 } from "../graphql/fetchUserGoals";
 import { useQuery } from "@apollo/client";
 import GoalsSectionComponent from "../components/coding/GoalsSectionComponent";
+import { Button } from "../components/ui/Button";
 
 export default function Goals(props) {
   const { user } = useAuth();
@@ -54,6 +55,9 @@ export default function Goals(props) {
         <div>Loading...</div>
       ) : (
         <div>
+          <div>
+            <Button label={"Create Goal"} />
+          </div>
           {goalsSections.map((section) => {
             return (
               <div>

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -1,9 +1,5 @@
 import { useQuery } from "@apollo/client";
-import {
-  ArchiveIcon,
-  CheckCircleIcon,
-  TrashIcon,
-} from "@heroicons/react/solid";
+import { ArchiveIcon, CheckCircleIcon } from "@heroicons/react/solid";
 import { format } from "date-fns";
 import { useRouter } from "next/router";
 import React, { useState } from "react";
@@ -82,13 +78,18 @@ const EditGoalsPage = () => {
             />
             <p className="font-bold">Target Completion Date</p>
             <input
-              type="text"
+              type="date"
               className="text-left p-2 border rounded-md shadow-md w-1/4"
-              value={
-                format(new Date(goalDetail.targetDate), "MMMM dd yyyy") ??
-                "No Date Set"
-              }
-              disabled
+              value={format(
+                new Date(editedGoalValues.targetDate),
+                "yyyy-MM-dd"
+              )}
+              onChange={(e) => {
+                setEditedGoalValues((prevState) => ({
+                  ...prevState,
+                  targetDate: new Date(e.target.value),
+                }));
+              }}
             />
           </div>
           <div className="grid grid-cols-12 items-center mt-8">

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -127,7 +127,7 @@ const EditGoalsPage = () => {
               disabled={goalDetail === editedGoalValues}
               onClick={() => {
                 // this is a workaround to remove __typename from the gql response which causes mutation to fail
-                const removeTypeNameForHasura = {
+                const editedGoalValuesForHasura = {
                   goalName: editedGoalValues.goalName,
                   userId: editedGoalValues.userId,
                   id: editedGoalValues.id,
@@ -139,7 +139,7 @@ const EditGoalsPage = () => {
 
                 saveEditedGoals({
                   variables: {
-                    objects: removeTypeNameForHasura,
+                    objects: editedGoalValuesForHasura,
                   },
                 });
               }}


### PR DESCRIPTION
primary changes: 
- stumbled upon a built-in date picker through the <input> html tag, which looks good and works pretty well
- added create goal button to goals overview - will create new page similar to edit goal page to add a brand new goal
- couple stylistic changes to clean up the overview page