### PR TITLE
fix app crash on profile page

### DIFF
--- a/components/coding/UserProfileSection.tsx
+++ b/components/coding/UserProfileSection.tsx
@@ -13,6 +13,9 @@ export type UserProfileSectionProps = {
 };
 
 export default function UserProfileSection({ user }: UserProfileSectionProps) {
+  const [userProfileData, setUserProfileData] =
+    useState<UserProfileData>(Object);
+
   const { loading: userProfileLoading } =
     useQuery<FetchUserProfileDataResponse>(FETCH_USER_PROFILE_DATA, {
       variables: {
@@ -29,9 +32,6 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
         });
       },
     });
-
-  const [userProfileData, setUserProfileData] =
-    useState<UserProfileData>(Object);
 
   return (
     <>


### PR DESCRIPTION
The error in the console was that the setUserProfile function was undefined. The userProfileData state var was not declared before the useQuery hook which calls the setter in its onComplete. Switched the order and I'm not able to repro the crash when I toggle between tabs. This order seems more correct anyways. 

Trying to think about why it might have worked in some cases... one theory is that maybe on the initial load, the query takes some time to complete which gives the state var time initialize. On ensuing loads the query loads from cache before the setter is initialized, hence undefined?
