### PR TITLE
attach upsert mutation to save button

### DIFF
--- a/components/skillRatings/SkillRow.tsx
+++ b/components/skillRatings/SkillRow.tsx
@@ -6,13 +6,6 @@ import {
 } from "../../redux/skillRatingsSlice";
 import SkillRowEmoji from "./SkillRowEmoji";
 
-export type SkillRowType = {
-  skillId: String;
-  sectionName: String;
-  skillName: String;
-  skillRating: Number;
-};
-
 export type SkillRowProps = {
   skillRow: SkillRatingsRow;
 };
@@ -20,7 +13,7 @@ export type SkillRowProps = {
 export default function SkillRow({ skillRow }: SkillRowProps) {
   const { skillRatings } = useSelector(skillRatingsSelector);
   const index = skillRatings.findIndex(
-    (obj) => obj.skillId == skillRow.skillId
+    (obj) => obj.userSkillId == skillRow.userSkillId
   );
 
   const renderEmojiByRating = (skillRating: Number) => {
@@ -44,7 +37,7 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
       </div>
       <p className="col-start-2 col-span-3 text-xl">{skillRow.skillName}</p>
       <p className="text-xl">{skillRow.studentRating}</p>
-      <SkillRowEmoji skillId={skillRow.skillId} />
+      <SkillRowEmoji userSkillId={skillRow.userSkillId} />
     </div>
   );
 }

--- a/components/skillRatings/SkillRow.tsx
+++ b/components/skillRatings/SkillRow.tsx
@@ -16,7 +16,7 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
     (obj) => obj.userSkillId == skillRow.userSkillId
   );
 
-  const renderEmojiByRating = (skillRating: Number) => {
+  const renderEmojiByRating = (skillRating: number) => {
     if (skillRating == 0) {
       return "😶";
     } else if (skillRating < 30) {
@@ -37,7 +37,10 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
       </div>
       <p className="col-start-2 col-span-3 text-xl">{skillRow.skillName}</p>
       <p className="text-xl">{skillRow.studentRating}</p>
-      <SkillRowEmoji userSkillId={skillRow.userSkillId} />
+      <SkillRowEmoji
+        userSkillId={skillRow.userSkillId}
+        studentRating={skillRow.studentRating}
+      />
     </div>
   );
 }

--- a/components/skillRatings/SkillRowEmoji.tsx
+++ b/components/skillRatings/SkillRowEmoji.tsx
@@ -4,9 +4,10 @@ import { updateSkillRatings } from "../../redux/skillRatingsSlice";
 
 export interface EmojiSliderProps {
   userSkillId: String;
+  studentRating: number;
 }
 
-const EmojiSlider = ({ userSkillId }: EmojiSliderProps) => {
+const EmojiSlider = ({ userSkillId, studentRating }: EmojiSliderProps) => {
   const dispatch = useDispatch();
 
   function handleChange(e) {
@@ -16,7 +17,12 @@ const EmojiSlider = ({ userSkillId }: EmojiSliderProps) => {
 
   return (
     <div className="flex flex-col items-center">
-      <input type="range" onChange={handleChange} className="w-44" />
+      <input
+        type="range"
+        onChange={handleChange}
+        className="w-44"
+        value={studentRating}
+      />
     </div>
   );
 };

--- a/components/skillRatings/SkillRowEmoji.tsx
+++ b/components/skillRatings/SkillRowEmoji.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch } from "react-redux";
 import { updateSkillRatings } from "../../redux/skillRatingsSlice";
 
 export interface EmojiSliderProps {
-  skillId: String;
+  userSkillId: String;
 }
 
-const EmojiSlider = ({ skillId }: EmojiSliderProps) => {
+const EmojiSlider = ({ userSkillId }: EmojiSliderProps) => {
   const dispatch = useDispatch();
 
   function handleChange(e) {
     const newStudentRating = Number(e.target.value) || 0;
-    dispatch(updateSkillRatings({ newStudentRating, skillId }));
+    dispatch(updateSkillRatings({ newStudentRating, userSkillId }));
   }
 
   return (

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -47,12 +47,13 @@ export default function SkillRatings(props) {
   };
 
   return (
-    <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
-      <div>
+    <div className="flex flex-row overflow-auto-bg-scroll">
+      <div className="flex flex-col p-4 m-4">
+        {skillRatings && <SkillSection skillSection={skillRatings} />}
+      </div>
+      <div className="p-4 mr-8 mt-8">
         <Button label="Save" />
       </div>
-      <p className="text-xl font-bold">Skills</p>
-      {skillRatings && <SkillSection skillSection={skillRatings} />}
     </div>
   );
 }

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import SkillSection from "../components/skillRatings/SkillSection";
@@ -8,6 +8,7 @@ import {
   FETCH_USER_SKILLS_RATINGS,
   UserSkillsRatings,
 } from "../graphql/fetchUserSkillsRatings";
+import { UPSERT_USER_SKILL_RATINGS } from "../graphql/upsertUserSkillRatings";
 
 import { useAuth } from "../lib/authContext";
 import {
@@ -26,17 +27,26 @@ export default function SkillRatings(props) {
       userId: user.uid,
     },
     onCompleted: (data) => {
+      console.log(
+        "data before being transformed and dispatched",
+        data.intro_course_skills_user
+      );
       dispatch(
         setSkillRatings(transformSkillRating(data.intro_course_skills_user))
       );
     },
   });
 
+  const [saveSkillRatings] = useMutation(UPSERT_USER_SKILL_RATINGS, {
+    refetchQueries: [{ query: FETCH_USER_SKILLS_RATINGS }],
+  });
+
   const transformSkillRating = (skillRatings: UserSkillsRatings[]) => {
     // map to redux type
     const mappedSkillRatings: SkillRatingsRow[] = skillRatings.map((row) => {
       return {
-        skillId: row.id,
+        userSkillId: row.id,
+        skillId: row.intro_course_skill["id"],
         skillName: row.intro_course_skill["name"],
         unitName: row.intro_course_skill["intro_course_unit"]["title"],
         studentRating: parseInt(row.studentRating),
@@ -46,13 +56,36 @@ export default function SkillRatings(props) {
     return mappedSkillRatings;
   };
 
+  const transformSkillRatingForDB = (skillRatings: SkillRatingsRow[]) => {
+    // map from redux type to write back to DB
+    const transformedOutput = skillRatings.map((row) => {
+      return {
+        userId: user.uid,
+        id: row.userSkillId,
+        skillId: row.skillId,
+        studentRating: row.studentRating,
+      };
+    });
+
+    return transformedOutput;
+  };
+
   return (
     <div className="flex flex-row overflow-auto-bg-scroll">
       <div className="flex flex-col p-4 m-4">
         {skillRatings && <SkillSection skillSection={skillRatings} />}
       </div>
       <div className="p-4 mr-8 mt-8">
-        <Button label="Save" />
+        <Button
+          label="Save"
+          onClick={() =>
+            saveSkillRatings({
+              variables: {
+                objects: transformSkillRatingForDB(skillRatings),
+              },
+            })
+          }
+        />
       </div>
     </div>
   );

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -27,10 +27,6 @@ export default function SkillRatings(props) {
       userId: user.uid,
     },
     onCompleted: (data) => {
-      console.log(
-        "data before being transformed and dispatched",
-        data.intro_course_skills_user
-      );
       dispatch(
         setSkillRatings(transformSkillRating(data.intro_course_skills_user))
       );

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -35,6 +35,9 @@ export default function SkillRatings(props) {
 
   const [saveSkillRatings] = useMutation(UPSERT_USER_SKILL_RATINGS, {
     refetchQueries: [{ query: FETCH_USER_SKILLS_RATINGS }],
+    onCompleted: () => {
+      alert("Your skill ratings have been saved successfully.");
+    },
   });
 
   const transformSkillRating = (skillRatings: UserSkillsRatings[]) => {

--- a/redux/skillRatingsSlice.ts
+++ b/redux/skillRatingsSlice.ts
@@ -6,6 +6,7 @@ export type SkillRatingsState = {
 };
 
 export type SkillRatingsRow = {
+  userSkillId: String;
   skillId: String;
   skillName: String;
   unitName: String;
@@ -33,11 +34,11 @@ export const skillRatingsSlice: Slice = createSlice({
 
     updateSkillRatings: (
       state: SkillRatingsState,
-      action: PayloadAction<{ newStudentRating: Number; skillId: String }>
+      action: PayloadAction<{ newStudentRating: Number; userSkillId: String }>
     ) => {
       if (action.type == "skillRatings/updateSkillRatings") {
         const index = state.skillRatings.findIndex(
-          (obj) => obj.skillId == action.payload.skillId
+          (obj) => obj.userSkillId == action.payload.userSkillId
         );
         state.skillRatings[index].studentRating =
           action.payload.newStudentRating;

--- a/redux/skillRatingsSlice.ts
+++ b/redux/skillRatingsSlice.ts
@@ -10,7 +10,7 @@ export type SkillRatingsRow = {
   skillId: String;
   skillName: String;
   unitName: String;
-  studentRating: Number;
+  studentRating: number;
 };
 
 const initialState: SkillRatingsState = {
@@ -34,7 +34,7 @@ export const skillRatingsSlice: Slice = createSlice({
 
     updateSkillRatings: (
       state: SkillRatingsState,
-      action: PayloadAction<{ newStudentRating: Number; userSkillId: String }>
+      action: PayloadAction<{ newStudentRating: number; userSkillId: String }>
     ) => {
       if (action.type == "skillRatings/updateSkillRatings") {
         const index = state.skillRatings.findIndex(


### PR DESCRIPTION
When students hit the save button on the skillRatings page, the new skill ratings are written back to the DB through an upsert mutation, and they are alerted that this action is successful.

couple other changes here:
- had to restructure some types to differentiate between "skillId" and "userSkillId"... skillId is the id for a given skill i.e "I can use <p> tags" whereas userSkillId refers to the id of an individual user's rating for that skillId
- make initial value of the slider the studentRating fetched from the DB
- consistently use the "number" type instead of the "Number" type