### PR TITLE
restructure gql queries for initial visit to skillRatings 

### DIFF
--- a/components/skillRatings/SkillRow.tsx
+++ b/components/skillRatings/SkillRow.tsx
@@ -6,13 +6,6 @@ import {
 } from "../../redux/skillRatingsSlice";
 import SkillRowEmoji from "./SkillRowEmoji";
 
-export type SkillRowType = {
-  skillId: String;
-  sectionName: String;
-  skillName: String;
-  skillRating: Number;
-};
-
 export type SkillRowProps = {
   skillRow: SkillRatingsRow;
 };
@@ -20,7 +13,7 @@ export type SkillRowProps = {
 export default function SkillRow({ skillRow }: SkillRowProps) {
   const { skillRatings } = useSelector(skillRatingsSelector);
   const index = skillRatings.findIndex(
-    (obj) => obj.skillId == skillRow.skillId
+    (obj) => obj.userSkillId == skillRow.userSkillId
   );
 
   const renderEmojiByRating = (skillRating: Number) => {
@@ -44,7 +37,7 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
       </div>
       <p className="col-start-2 col-span-3 text-xl">{skillRow.skillName}</p>
       <p className="text-xl">{skillRow.studentRating}</p>
-      <SkillRowEmoji skillId={skillRow.skillId} />
+      <SkillRowEmoji userSkillId={skillRow.userSkillId} />
     </div>
   );
 }

--- a/components/skillRatings/SkillRow.tsx
+++ b/components/skillRatings/SkillRow.tsx
@@ -16,7 +16,7 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
     (obj) => obj.userSkillId == skillRow.userSkillId
   );
 
-  const renderEmojiByRating = (skillRating: Number) => {
+  const renderEmojiByRating = (skillRating: number) => {
     if (skillRating == 0) {
       return "😶";
     } else if (skillRating < 30) {
@@ -37,7 +37,10 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
       </div>
       <p className="col-start-2 col-span-3 text-xl">{skillRow.skillName}</p>
       <p className="text-xl">{skillRow.studentRating}</p>
-      <SkillRowEmoji userSkillId={skillRow.userSkillId} />
+      <SkillRowEmoji
+        userSkillId={skillRow.userSkillId}
+        studentRating={skillRow.studentRating}
+      />
     </div>
   );
 }

--- a/components/skillRatings/SkillRowEmoji.tsx
+++ b/components/skillRatings/SkillRowEmoji.tsx
@@ -4,9 +4,10 @@ import { updateSkillRatings } from "../../redux/skillRatingsSlice";
 
 export interface EmojiSliderProps {
   userSkillId: String;
+  studentRating: number;
 }
 
-const EmojiSlider = ({ userSkillId }: EmojiSliderProps) => {
+const EmojiSlider = ({ userSkillId, studentRating }: EmojiSliderProps) => {
   const dispatch = useDispatch();
 
   function handleChange(e) {
@@ -16,7 +17,12 @@ const EmojiSlider = ({ userSkillId }: EmojiSliderProps) => {
 
   return (
     <div className="flex flex-col items-center">
-      <input type="range" onChange={handleChange} className="w-44" />
+      <input
+        type="range"
+        onChange={handleChange}
+        className="w-44"
+        value={studentRating}
+      />
     </div>
   );
 };

--- a/components/skillRatings/SkillRowEmoji.tsx
+++ b/components/skillRatings/SkillRowEmoji.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch } from "react-redux";
 import { updateSkillRatings } from "../../redux/skillRatingsSlice";
 
 export interface EmojiSliderProps {
-  skillId: String;
+  userSkillId: String;
 }
 
-const EmojiSlider = ({ skillId }: EmojiSliderProps) => {
+const EmojiSlider = ({ userSkillId }: EmojiSliderProps) => {
   const dispatch = useDispatch();
 
   function handleChange(e) {
     const newStudentRating = Number(e.target.value) || 0;
-    dispatch(updateSkillRatings({ newStudentRating, skillId }));
+    dispatch(updateSkillRatings({ newStudentRating, userSkillId }));
   }
 
   return (

--- a/graphql/fetchUserSkillsRatings.ts
+++ b/graphql/fetchUserSkillsRatings.ts
@@ -3,12 +3,10 @@ import { gql } from "@apollo/client";
 export const FETCH_USER_SKILLS_RATINGS = gql`
   query fetchUserSkillsRatings($userId: String = "") {
     intro_course_skills {
-      createdAt
       id
       isVisible
       name
       unitId
-      updatedAt
       intro_course_unit {
         title
       }
@@ -21,14 +19,22 @@ export const FETCH_USER_SKILLS_RATINGS = gql`
   }
 `;
 
-export type FetchUserSkillsRatings = {
-  intro_course_skills_user: Array<UserSkillsRatings>;
+export type FetchUserSkillsDBResponse = {
+  intro_course_skills: Array<UserSkills>;
+};
+
+export type UserSkills = {
+  name: String;
+  id: string;
+  unitId: boolean;
+  intro_course_unit: CourseUnitDescription;
+  intro_course_skills_users: Array<UserSkillsRatings>;
 };
 
 export type UserSkillsRatings = {
   id: String;
   studentRating: string;
-  intro_course_skill: boolean;
+  // intro_course_skill: boolean;
 };
 
 export type SkillDescription = {
@@ -40,4 +46,10 @@ export type SkillDescription = {
 
 export type CourseUnitDescription = {
   title: string;
+};
+
+// old types
+
+export type FetchUserSkillsRatings = {
+  intro_course_skills_user: Array<UserSkillsRatings>;
 };

--- a/graphql/fetchUserSkillsRatings.ts
+++ b/graphql/fetchUserSkillsRatings.ts
@@ -24,7 +24,7 @@ export type FetchUserSkillsDBResponse = {
 };
 
 export type UserSkills = {
-  name: String;
+  name: string;
   id: string;
   unitId: boolean;
   intro_course_unit: CourseUnitDescription;
@@ -32,13 +32,13 @@ export type UserSkills = {
 };
 
 export type UserSkillsRatings = {
-  id: String;
+  id: string;
   studentRating: string;
   // intro_course_skill: boolean;
 };
 
 export type SkillDescription = {
-  name: String;
+  name: string;
   id: string;
   unitId: boolean;
   intro_course_unit: CourseUnitDescription;

--- a/graphql/fetchUserSkillsRatings.ts
+++ b/graphql/fetchUserSkillsRatings.ts
@@ -2,16 +2,20 @@ import { gql } from "@apollo/client";
 
 export const FETCH_USER_SKILLS_RATINGS = gql`
   query fetchUserSkillsRatings($userId: String = "") {
-    intro_course_skills_user(where: { userId: { _eq: $userId } }) {
+    intro_course_skills {
+      createdAt
       id
-      studentRating
-      intro_course_skill {
-        name
+      isVisible
+      name
+      unitId
+      updatedAt
+      intro_course_unit {
+        title
+      }
+      intro_course_skills_users(where: { userId: { _eq: $userId } }) {
         id
-        unitId
-        intro_course_unit {
-          title
-        }
+        userId
+        studentRating
       }
     }
   }

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -47,12 +47,13 @@ export default function SkillRatings(props) {
   };
 
   return (
-    <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
-      <div>
+    <div className="flex flex-row overflow-auto-bg-scroll">
+      <div className="flex flex-col p-4 m-4">
+        {skillRatings && <SkillSection skillSection={skillRatings} />}
+      </div>
+      <div className="p-4 mr-8 mt-8">
         <Button label="Save" />
       </div>
-      <p className="text-xl font-bold">Skills</p>
-      {skillRatings && <SkillSection skillSection={skillRatings} />}
     </div>
   );
 }

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import SkillSection from "../components/skillRatings/SkillSection";
@@ -8,6 +8,7 @@ import {
   FETCH_USER_SKILLS_RATINGS,
   UserSkillsRatings,
 } from "../graphql/fetchUserSkillsRatings";
+import { UPSERT_USER_SKILL_RATINGS } from "../graphql/upsertUserSkillRatings";
 
 import { useAuth } from "../lib/authContext";
 import {
@@ -26,17 +27,26 @@ export default function SkillRatings(props) {
       userId: user.uid,
     },
     onCompleted: (data) => {
+      console.log(
+        "data before being transformed and dispatched",
+        data.intro_course_skills_user
+      );
       dispatch(
         setSkillRatings(transformSkillRating(data.intro_course_skills_user))
       );
     },
   });
 
+  const [saveSkillRatings] = useMutation(UPSERT_USER_SKILL_RATINGS, {
+    refetchQueries: [{ query: FETCH_USER_SKILLS_RATINGS }],
+  });
+
   const transformSkillRating = (skillRatings: UserSkillsRatings[]) => {
     // map to redux type
     const mappedSkillRatings: SkillRatingsRow[] = skillRatings.map((row) => {
       return {
-        skillId: row.id,
+        userSkillId: row.id,
+        skillId: row.intro_course_skill["id"],
         skillName: row.intro_course_skill["name"],
         unitName: row.intro_course_skill["intro_course_unit"]["title"],
         studentRating: parseInt(row.studentRating),
@@ -46,13 +56,36 @@ export default function SkillRatings(props) {
     return mappedSkillRatings;
   };
 
+  const transformSkillRatingForDB = (skillRatings: SkillRatingsRow[]) => {
+    // map from redux type to write back to DB
+    const transformedOutput = skillRatings.map((row) => {
+      return {
+        userId: user.uid,
+        id: row.userSkillId,
+        skillId: row.skillId,
+        studentRating: row.studentRating,
+      };
+    });
+
+    return transformedOutput;
+  };
+
   return (
     <div className="flex flex-row overflow-auto-bg-scroll">
       <div className="flex flex-col p-4 m-4">
         {skillRatings && <SkillSection skillSection={skillRatings} />}
       </div>
       <div className="p-4 mr-8 mt-8">
-        <Button label="Save" />
+        <Button
+          label="Save"
+          onClick={() =>
+            saveSkillRatings({
+              variables: {
+                objects: transformSkillRatingForDB(skillRatings),
+              },
+            })
+          }
+        />
       </div>
     </div>
   );

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -27,10 +27,6 @@ export default function SkillRatings(props) {
       userId: user.uid,
     },
     onCompleted: (data) => {
-      console.log(
-        "data before being transformed and dispatched",
-        data.intro_course_skills_user
-      );
       dispatch(
         setSkillRatings(transformSkillRating(data.intro_course_skills_user))
       );

--- a/pages/skillRatings.tsx
+++ b/pages/skillRatings.tsx
@@ -35,6 +35,9 @@ export default function SkillRatings(props) {
 
   const [saveSkillRatings] = useMutation(UPSERT_USER_SKILL_RATINGS, {
     refetchQueries: [{ query: FETCH_USER_SKILLS_RATINGS }],
+    onCompleted: () => {
+      alert("Your skill ratings have been saved successfully.");
+    },
   });
 
   const transformSkillRating = (skillRatings: UserSkillsRatings[]) => {

--- a/redux/skillRatingsSlice.ts
+++ b/redux/skillRatingsSlice.ts
@@ -6,6 +6,7 @@ export type SkillRatingsState = {
 };
 
 export type SkillRatingsRow = {
+  userSkillId: String;
   skillId: String;
   skillName: String;
   unitName: String;
@@ -33,11 +34,11 @@ export const skillRatingsSlice: Slice = createSlice({
 
     updateSkillRatings: (
       state: SkillRatingsState,
-      action: PayloadAction<{ newStudentRating: Number; skillId: String }>
+      action: PayloadAction<{ newStudentRating: Number; userSkillId: String }>
     ) => {
       if (action.type == "skillRatings/updateSkillRatings") {
         const index = state.skillRatings.findIndex(
-          (obj) => obj.skillId == action.payload.skillId
+          (obj) => obj.userSkillId == action.payload.userSkillId
         );
         state.skillRatings[index].studentRating =
           action.payload.newStudentRating;

--- a/redux/skillRatingsSlice.ts
+++ b/redux/skillRatingsSlice.ts
@@ -6,10 +6,10 @@ export type SkillRatingsState = {
 };
 
 export type SkillRatingsRow = {
-  userSkillId: String;
-  skillId: String;
-  skillName: String;
-  unitName: String;
+  userSkillId: string;
+  skillId: string;
+  skillName: string;
+  unitName: string;
   studentRating: number;
 };
 
@@ -34,7 +34,7 @@ export const skillRatingsSlice: Slice = createSlice({
 
     updateSkillRatings: (
       state: SkillRatingsState,
-      action: PayloadAction<{ newStudentRating: number; userSkillId: String }>
+      action: PayloadAction<{ newStudentRating: number; userSkillId: string }>
     ) => {
       if (action.type == "skillRatings/updateSkillRatings") {
         const index = state.skillRatings.findIndex(

--- a/redux/skillRatingsSlice.ts
+++ b/redux/skillRatingsSlice.ts
@@ -10,7 +10,7 @@ export type SkillRatingsRow = {
   skillId: String;
   skillName: String;
   unitName: String;
-  studentRating: Number;
+  studentRating: number;
 };
 
 const initialState: SkillRatingsState = {
@@ -34,7 +34,7 @@ export const skillRatingsSlice: Slice = createSlice({
 
     updateSkillRatings: (
       state: SkillRatingsState,
-      action: PayloadAction<{ newStudentRating: Number; userSkillId: String }>
+      action: PayloadAction<{ newStudentRating: number; userSkillId: String }>
     ) => {
       if (action.type == "skillRatings/updateSkillRatings") {
         const index = state.skillRatings.findIndex(


### PR DESCRIPTION
This PR makes several changes to account for when a student visits the skillRatings page for the first time, or if new skill(s) are added:
- restructure gql query so all skills are pulled instead of just ones with a previous studentRating
- create new / modify existing types fit new gql query response
- modify transformers and reducers to account for new data structure
- assign a "tempId" for each new, unrated skill... this enables the reducer to differentiate between different skills and sliders before a permanent userSkillId is assigned by Hasura

I ran into an edge case for the following scenario: 
1) user visits skillRatings for first time, 
2) user rates their skills and hits save button 
3) user re-ranks skills and tries to save again. 


- to solve for this, I added refetch for FetchUserSkillRatings to the onError of saveSkillRatings mutation to account for the 