### PR TITLE
fix naming for skillRatingsState

### DIFF
--- a/redux/rootReducer.ts
+++ b/redux/rootReducer.ts
@@ -30,7 +30,7 @@ type State = {
   quizState: QuizState;
   lessonState: LessonState;
   sidebarState: SidebarState;
-  skillRatingsSlice: SkillRatingsState;
+  skillRatingsState: SkillRatingsState;
 };
 const diagnosticReducer: Reducer = diagnosticSlice.reducer;
 const practiceTrackerReducer = practiceTrackerSlice.reducer;


### PR DESCRIPTION
really small naming mistake that didn't affect this project, but I made the same mistake in my own project and it led me down some bizarre paths.

skillRatingsState was incorrectly named skillRatingsSlice which prevented the actual types from being sent to the selectors in the skillRatings page. I guess my implementation worked with typeless selectors which is why I didn't catch it before. 

