### PR TITLE
goal page enhancements

### DIFF
--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -37,7 +37,7 @@ export default function GoalsSection({
           <div
             className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${
               differenceInCalendarDays(new Date(goal.targetDate), new Date()) <=
-              2
+              1
                 ? "text-red-500 bg-yellow-100"
                 : differenceInCalendarDays(
                     new Date(goal.targetDate),

--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -1,11 +1,5 @@
 import { PencilAltIcon, PencilIcon } from "@heroicons/react/outline";
-import {
-  differenceInCalendarDays,
-  differenceInDays,
-  format,
-  formatDistance,
-  isSameWeek,
-} from "date-fns";
+import { differenceInCalendarDays, format } from "date-fns";
 import moment from "moment";
 import Link from "next/link";
 import React from "react";
@@ -37,15 +31,26 @@ export default function GoalsSection({
           new Date(goal.targetDate),
           new Date()
         );
-        const goalStyle =
-          differenceInDays <= 1
-            ? `text-red-500 bg-yellow-100`
-            : differenceInDays <= 7
-            ? `text-red-500`
-            : "text-black-500 bg-none";
+        const returnGoalStyle = (targetDate: Date) => {
+          let goalStyle = "";
+          const daysRemaining = differenceInCalendarDays(
+            new Date(goal.targetDate),
+            new Date()
+          );
+          if (daysRemaining <= 1) {
+            goalStyle = " text-red-500 bg-yellow-100";
+          } else if (daysRemaining <= 7) {
+            goalStyle = " text-red-500";
+          } else {
+            goalStyle = " text-black-500";
+          }
+          return goalStyle;
+        };
         return (
           <div
-            className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${goalStyle}`}
+            className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${returnGoalStyle(
+              goal.targetDate
+            )}`}
           >
             <p>{index + 1}.</p>
             <p className="col-span-2 md:col-span-4">{goal.goalName}</p>

--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -1,5 +1,12 @@
 import { PencilAltIcon, PencilIcon } from "@heroicons/react/outline";
-import { format } from "date-fns";
+import {
+  differenceInCalendarDays,
+  differenceInDays,
+  format,
+  formatDistance,
+  isSameWeek,
+} from "date-fns";
+import moment from "moment";
 import Link from "next/link";
 import React from "react";
 import { UserGoalsData } from "../../graphql/fetchUserGoals";
@@ -16,17 +23,30 @@ export default function GoalsSection({
   return (
     <div>
       {userGoals.length > 0 && (
-        <div className="grid grid-cols-5 text-sm font-semibold text-center border-b-2 md:grid-cols-10 md:text-lg">
+        <div className="grid grid-cols-5 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
           <p className="font-semibold">{sectionName}</p>
           <p className="col-span-2 md:col-span-4">Goal</p>
           <p className="hidden md:block md:col-span-2">Date Added</p>
           <p className="font-semibold md:col-span-2">Target Date</p>
+          <p className="hidden md:block md:col-span-2">Days Remaining</p>
         </div>
       )}
 
       {userGoals.map((goal, index) => {
         return (
-          <div className="grid grid-cols-5 my-2 text-sm text-center md:grid-cols-10 md:text-lg place-items-center">
+          <div
+            className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${
+              differenceInCalendarDays(new Date(goal.targetDate), new Date()) <=
+              2
+                ? "text-red-500 bg-yellow-100"
+                : differenceInCalendarDays(
+                    new Date(goal.targetDate),
+                    new Date()
+                  ) <= 7
+                ? " text-red-500"
+                : "text-black-500 bg-none"
+            }`}
+          >
             <p>{index + 1}.</p>
             <p className="col-span-2 md:col-span-4">{goal.goalName}</p>
             <p className="hidden md:block md:col-span-2">
@@ -35,7 +55,9 @@ export default function GoalsSection({
             <p className="md:col-span-2">
               {format(new Date(goal.targetDate), "MM/dd/yyyy")}
             </p>
-
+            <p className="hidden md:block md:col-span-2">
+              {differenceInCalendarDays(new Date(goal.targetDate), new Date())}
+            </p>
             <Link href={"/goals/" + goal.id}>
               <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
             </Link>

--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -33,19 +33,19 @@ export default function GoalsSection({
       )}
 
       {userGoals.map((goal, index) => {
+        const differenceInDays = differenceInCalendarDays(
+          new Date(goal.targetDate),
+          new Date()
+        );
+        const goalStyle =
+          differenceInDays <= 1
+            ? `text-red-500 bg-yellow-100`
+            : differenceInDays <= 7
+            ? `text-red-500`
+            : "text-black-500 bg-none";
         return (
           <div
-            className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${
-              differenceInCalendarDays(new Date(goal.targetDate), new Date()) <=
-              1
-                ? "text-red-500 bg-yellow-100"
-                : differenceInCalendarDays(
-                    new Date(goal.targetDate),
-                    new Date()
-                  ) <= 7
-                ? " text-red-500"
-                : "text-black-500 bg-none"
-            }`}
+            className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${goalStyle}`}
           >
             <p>{index + 1}.</p>
             <p className="col-span-2 md:col-span-4">{goal.goalName}</p>
@@ -55,9 +55,7 @@ export default function GoalsSection({
             <p className="md:col-span-2">
               {format(new Date(goal.targetDate), "MM/dd/yyyy")}
             </p>
-            <p className="hidden md:block md:col-span-2">
-              {differenceInCalendarDays(new Date(goal.targetDate), new Date())}
-            </p>
+            <p className="hidden md:block md:col-span-2">{differenceInDays}</p>
             <Link href={"/goals/" + goal.id}>
               <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
             </Link>


### PR DESCRIPTION

![Screen Shot 2022-10-12 at 9 45 28 PM](https://user-images.githubusercontent.com/111075855/195423366-60c7c1df-bcbe-4af2-acd6-591bbec9e4e3.png)


- Expanded columns in grid of md screen width by 2
- Added column "Days Remaining" to be calculated using differenceInCalendarDays date-fn (targetDate-current date)
- set text to red if the goal is within 7 days
- set background to yellow and text to red if goal is within 1 day
![Screen Shot 2022-10-12 at 9 39 05 PM](https://user-images.githubusercontent.com/111075855/195423406-bc9c5f5b-06f6-43db-be95-fd4ecdd683fb.png)

- addressed mobile responsiveness by allowing this new days remaining column to be hidden in mobile view, while still having the highlights operational.