### PR TITLE
add Clear text button to Goal Notes

### DIFF
--- a/graphql/fetchUserGoals.ts
+++ b/graphql/fetchUserGoals.ts
@@ -5,6 +5,7 @@ export const FETCH_USER_GOALS = gql`
     user_goals(where: { userId: { _eq: $userId } }) {
       createdAt
       goalName
+      goalNotes
       id
       updatedAt
       userId

--- a/graphql/fetchUserGoals.ts
+++ b/graphql/fetchUserGoals.ts
@@ -22,6 +22,7 @@ export const FETCH_USER_GOAL_DETAIL = gql`
     ) {
       createdAt
       goalName
+      goalNotes
       id
       updatedAt
       userId
@@ -39,6 +40,7 @@ export type FetchUserGoalsDataResponse = {
 export type UserGoalsData = {
   createdAt: Date;
   goalName: string;
+  goalNotes?: string;
   id: string;
   updatedAt: Date;
   userId: string;

--- a/graphql/upsertUserGoals.ts
+++ b/graphql/upsertUserGoals.ts
@@ -11,6 +11,7 @@ export const UPSERT_USER_GOALS = gql`
         constraint: user_goals_pkey
         update_columns: [
           goalName
+          goalNotes
           isArchived
           isComplete
           updatedAt
@@ -22,6 +23,7 @@ export const UPSERT_USER_GOALS = gql`
       returning {
         id
         goalName
+        goalNotes
         isArchived
         isComplete
         targetDate

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -18,6 +18,7 @@ import { useAuth } from "../../lib/authContext";
 import { useMutation } from "@apollo/client";
 import { UPSERT_USER_GOALS } from "../../graphql/upsertUserGoals";
 import { REMOVE_USER_GOAL } from "../../graphql/removeUserGoal";
+import { ArrowCircleRightIcon } from "@heroicons/react/outline";
 
 const EditGoalsPage = () => {
   const { user } = useAuth();
@@ -26,6 +27,7 @@ const EditGoalsPage = () => {
   const { slug } = router.query;
 
   const [editedGoalValues, setEditedGoalValues] = useState<UserGoalsData>();
+  const [editGoalNotes, setEditGoalNotes] = useState<boolean>();
 
   const [saveEditedGoals] = useMutation(UPSERT_USER_GOALS, {
     refetchQueries: [{ query: FETCH_USER_GOALS }],
@@ -82,12 +84,22 @@ const EditGoalsPage = () => {
                 please keep your goal under 60 characters
               </p>
             )}
-            <p className="font-bold">Write An Actionable Goal Outline</p>
-
+            <div className="flex">
+              <ArrowCircleRightIcon
+                className={
+                  editGoalNotes
+                    ? "h-5 w-5 mr-2  text-yellow-600"
+                    : " mr-2 h-5 w-5 "
+                }
+                onClick={() => setEditGoalNotes(!editGoalNotes)}
+              />
+              <p className="font-bold">Write An Actionable Goal Outline</p>
+            </div>
             <textarea
               className={`text-left p-2 border rounded-md shadow-md w-full md:w-1/2 text-murkrow `}
               placeholder={goalDetail.goalNotes}
               value={editedGoalValues.goalNotes}
+              disabled={!editGoalNotes}
               onChange={(e) => {
                 setEditedGoalValues((prevState) => ({
                   ...prevState,
@@ -95,6 +107,7 @@ const EditGoalsPage = () => {
                 }));
               }}
             />
+
             <p className="font-bold">Created On</p>
             <input
               type="text"

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -76,6 +76,19 @@ const EditGoalsPage = () => {
                 }));
               }}
             />
+            <p className="font-bold">Write An Actionable Goal Outline</p>
+
+            <textarea
+              className={`text-left p-2 border rounded-md shadow-md w-full md:w-1/2 text-murkrow `}
+              placeholder={goalDetail.goalNotes}
+              value={editedGoalValues.goalNotes}
+              onChange={(e) => {
+                setEditedGoalValues((prevState) => ({
+                  ...prevState,
+                  goalName: e.target.value,
+                }));
+              }}
+            />
             {editedGoalValues.goalName.length > 60 && (
               <p className="text-xs text-red-600">
                 please keep your goal under 60 characters

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -76,6 +76,12 @@ const EditGoalsPage = () => {
                 }));
               }}
             />
+
+            {editedGoalValues.goalName.length > 60 && (
+              <p className="text-xs text-red-600">
+                please keep your goal under 60 characters
+              </p>
+            )}
             <p className="font-bold">Write An Actionable Goal Outline</p>
 
             <textarea
@@ -85,15 +91,11 @@ const EditGoalsPage = () => {
               onChange={(e) => {
                 setEditedGoalValues((prevState) => ({
                   ...prevState,
-                  goalName: e.target.value,
+                  goalNotes: e.target.value,
                 }));
               }}
             />
-            {editedGoalValues.goalName.length > 60 && (
-              <p className="text-xs text-red-600">
-                please keep your goal under 60 characters
-              </p>
-            )}
+
             <p className="font-bold">Created On</p>
             <input
               type="text"

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -95,7 +95,6 @@ const EditGoalsPage = () => {
                 }));
               }}
             />
-
             <p className="font-bold">Created On</p>
             <input
               type="text"
@@ -176,6 +175,7 @@ const EditGoalsPage = () => {
                   // this is a workaround to remove __typename from the gql response which causes mutation to fail
                   const editedGoalValuesForHasura = {
                     goalName: editedGoalValues.goalName,
+                    goalNotes: editedGoalValues.goalNotes,
                     userId: editedGoalValues.userId,
                     id: editedGoalValues.id,
                     isArchived: editedGoalValues.isArchived,

--- a/pages/goals/[slug].tsx
+++ b/pages/goals/[slug].tsx
@@ -6,7 +6,7 @@ import {
 } from "@heroicons/react/solid";
 import { format } from "date-fns";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Button } from "../../components/ui/Button";
 import {
   FetchUserGoalsDataResponse,
@@ -25,7 +25,11 @@ const EditGoalsPage = () => {
 
   const router = useRouter();
   const { slug } = router.query;
+  const inputRef = useRef(null);
 
+  const resetFileInput = () => {
+    inputRef.current.value = null;
+  };
   const [editedGoalValues, setEditedGoalValues] = useState<UserGoalsData>();
   const [editGoalNotes, setEditGoalNotes] = useState<boolean>();
 
@@ -100,6 +104,7 @@ const EditGoalsPage = () => {
               placeholder={goalDetail.goalNotes}
               value={editedGoalValues.goalNotes}
               disabled={!editGoalNotes}
+              ref={inputRef}
               onChange={(e) => {
                 setEditedGoalValues((prevState) => ({
                   ...prevState,
@@ -107,6 +112,11 @@ const EditGoalsPage = () => {
                 }));
               }}
             />
+            <Button
+              label="Clear Text"
+              onClick={resetFileInput}
+              disabled={!editGoalNotes}
+            ></Button>
 
             <p className="font-bold">Created On</p>
             <input


### PR DESCRIPTION
Not sure if this feature is necessary.  Used the useRef hook and set it to null so that the notes box can be cleared by the user if desired. 
Also set the local state variable to match that of the icon that disables the input box so that the button is disabled as well.
![Screen Shot 2022-10-30 at 9 26 35 PM](https://user-images.githubusercontent.com/111075855/198897737-d4f049be-13b9-4162-a56f-1ccbc0d9f7fa.png)
![Screen Shot 2022-10-30 at 9 26 18 PM](https://user-images.githubusercontent.com/111075855/198897741-b4b00e83-d8fb-41fb-bbfa-2dcf2caa0a97.png)
