### PR TITLE
modify assignments workflow to prevent more than one submission per user

### DIFF
--- a/components/coding/studentPortal/AssignmentComponent.tsx
+++ b/components/coding/studentPortal/AssignmentComponent.tsx
@@ -37,6 +37,7 @@ export type AssignmentComponentData =
       codeSandboxTitle: string;
       link: string;
       placeholder: string;
+      assignmentId: string;
     }
   | {
       component: "custom";
@@ -51,7 +52,6 @@ export type AssignmentComponentData =
       component: "loom-video";
       text?: string;
       videoId: string;
-
     }
   | {
       component: "completed";
@@ -97,7 +97,8 @@ export default function AssignmentComponent({
         <h1 className="font-bold">{data.codeSandboxTitle}</h1>
         <AssignmentInputBox
           placeholder={data.placeholder}
-          submission_link={""}
+          submissionLink={""}
+          assignmentId={data.assignmentId}
         />{" "}
       </>
     );
@@ -119,7 +120,7 @@ export default function AssignmentComponent({
           moz-allowfullscreen
           allowFullScreen
           className="w-full h-96"
-        ></iframe>
+        />
       </div>
     );
   } else {

--- a/components/coding/studentPortal/AssignmentInputBox.tsx
+++ b/components/coding/studentPortal/AssignmentInputBox.tsx
@@ -1,24 +1,27 @@
 import { useMutation } from "@apollo/client";
 import router from "next/router";
 import React, { useState } from "react";
+import { FETCH_USER_ASSIGNMENT_SUBMISSIONS } from "../../../graphql/fetchUserAssignmentSubmissions";
 import { UPSERT_USER_ASSIGNMENT_SUBMISSIONS } from "../../../graphql/upsertUserAssignmentSubmissions";
 import { useAuth } from "../../../lib/authContext";
 import { Button } from "../../ui/Button";
 
 export interface AssignmentInputBoxProps {
   placeholder: string;
-  submission_link: string;
+  submissionLink: string;
+  assignmentId: string;
 }
 
 export const AssignmentInputBox: React.FC<AssignmentInputBoxProps> = ({
   placeholder,
-  submission_link,
+  assignmentId,
 }: AssignmentInputBoxProps) => {
   const [submissionInput, setSubmissionInput] = useState("");
   const { user } = useAuth();
   const submissionVariables = {
     user_id: user.uid,
     submission_link: submissionInput,
+    assignment_id: assignmentId,
   };
   const [saveAssignmentInput] = useMutation(
     UPSERT_USER_ASSIGNMENT_SUBMISSIONS,
@@ -27,14 +30,16 @@ export const AssignmentInputBox: React.FC<AssignmentInputBoxProps> = ({
         router.push("/studentPortal/web/React/assignments/template");
         alert("You have successfully saved your link.  Press continue.");
       },
+      refetchQueries: [FETCH_USER_ASSIGNMENT_SUBMISSIONS],
     }
   );
 
   return (
     <div className="grid grid-cols-1 gap-4 p-6 bg-white shadow-lg dark:bg-gray-900 ">
       <input
-        className={`text-left p-2 border rounded-md shadow-md w-full  text-murkrow 
-              }`}
+        className={
+          "text-left p-2 border rounded-md shadow-md w-full text-murkrow"
+        }
         id="input"
         type="string"
         value={submissionInput}

--- a/graphql/fetchUserAssignmentSubmissions.ts
+++ b/graphql/fetchUserAssignmentSubmissions.ts
@@ -1,7 +1,15 @@
 import { gql } from "@apollo/client";
 export const FETCH_USER_ASSIGNMENT_SUBMISSIONS = gql`
-  query fetchUserAssignmentSubmissions($user_id: String = "") {
-    user_assignment_submissions(where: { user_id: { _eq: $user_id } }) {
+  query fetchUserAssignmentSubmissions(
+    $user_id: String = ""
+    $assignmentId: uuid = ""
+  ) {
+    user_assignment_submissions(
+      where: {
+        user_id: { _eq: $user_id }
+        assignment_id: { _eq: $assignmentId }
+      }
+    ) {
       submission_link
       id
       user_id
@@ -19,4 +27,5 @@ export type UserAssignmentSubmissionsData = {
   submission_link: string;
   last_updated: Date;
   review_link: string;
+  assignmentId: string;
 };

--- a/graphql/upsertUserAssignmentSubmissions.ts
+++ b/graphql/upsertUserAssignmentSubmissions.ts
@@ -10,7 +10,7 @@ export const UPSERT_USER_ASSIGNMENT_SUBMISSIONS = gql`
     insert_user_assignment_submissions(
       objects: $objects
       on_conflict: {
-        constraint: user_assignment_submissions_pkey
+        constraint: user_assignment_submissions_user_id_assignment_id_key
         update_columns: [submission_link]
       }
     ) {

--- a/pages/studentPortal/web/React/assignments/template.tsx
+++ b/pages/studentPortal/web/React/assignments/template.tsx
@@ -22,12 +22,15 @@ const React2 = ({ incompleteStage, submittedStage, completedStage }) => {
   const [assignments, setAssignments] = useState<
     UserAssignmentSubmissionsData[]
   >([]);
+  // REQUIRED: create assignment in coding_assignments table to generate ID and paste here
+  const assignmentId = "2cf9156a-4f6f-452d-b09a-2c54f19a7b40";
 
   const { data } = useQuery<FetchUserAssignmentSubmissionsDataResponse>(
     FETCH_USER_ASSIGNMENT_SUBMISSIONS,
     {
       variables: {
         user_id: user.uid,
+        assignmentId: assignmentId,
       },
 
       onCompleted: (data: FetchUserAssignmentSubmissionsDataResponse) => {
@@ -92,6 +95,9 @@ const React2 = ({ incompleteStage, submittedStage, completedStage }) => {
 };
 
 export async function getServerSideProps({ params }) {
+  // REQUIRED: create assignment in coding_assignments table to generate ID and paste here
+  const assignmentId = "2cf9156a-4f6f-452d-b09a-2c54f19a7b40";
+
   const incompleteStage: AssignmentComponentData[] = await Promise.all([
     {
       component: "title",
@@ -126,6 +132,7 @@ export async function getServerSideProps({ params }) {
         "Please submit your assignment by pasting a link in the box below.",
       link: "",
       placeholder: "Assignment link goes here",
+      assignmentId: assignmentId,
     },
   ]);
   const submittedStage: AssignmentComponentData[] = await Promise.all([


### PR DESCRIPTION
This PR contains a few changes to account for assignmentId being added to Hasura:

- the coding_assignments table is now part of the whole assignments workflow - this table will have a record of every assignment
- there is now an assignment_id field in the user_assignment_submissions tables - it is foreign key to coding_assignments... we will only allow submissions with a valid assignment_id
- from a coach or content creator perspective, they must create a record of the assignment inside coding_assignments which generates an assignment_id uuid 
- for now, we store this key when creating a new assignment, then pass it into both the fetch / mutation queries when pulling or updating a student's assignment submissions 
- this solves for the following: 1) we now only check whether a submission has been made for that **specific** assignment (before it was all assignments) when determining which stage to render and 2) a user can only make one submission per assignment - if they change their submission, it only updates the submission link 