### PR TITLE
v2 profile page and ProfileHeaderComponent

### DIFF
--- a/components/coding/ProfileHeaderComponent.tsx
+++ b/components/coding/ProfileHeaderComponent.tsx
@@ -1,0 +1,113 @@
+import { useQuery } from "@apollo/client";
+import { format } from "date-fns";
+import React, { useState } from "react";
+import {
+  FetchUserBadgesCountResponse,
+  FETCH_USER_BADGES_COUNT,
+} from "../../graphql/fetchUserBadgesCount";
+
+import {
+  FetchUserProfileDataResponse,
+  FETCH_USER_PROFILE_DATA,
+  UserProfileData,
+} from "../../graphql/fetchUserProfile";
+
+export type UserProfileSectionProps = {
+  user: any;
+};
+
+export default function UserProfileSection({ user }: UserProfileSectionProps) {
+  const [userProfileData, setUserProfileData] =
+    useState<UserProfileData>(Object);
+
+  const [userBadgeCount, setUserBadgeCount] = useState<number>(0);
+
+  const { loading: userProfileLoading } =
+    useQuery<FetchUserProfileDataResponse>(FETCH_USER_PROFILE_DATA, {
+      variables: {
+        userId: user.uid,
+      },
+      onCompleted: (data) => {
+        if (data.users.length > 0) {
+          setUserProfileData({
+            typeName: data.users[0].__typename,
+            createdAt: data.users[0].created_at,
+            email: data.users[0].email,
+            lastSeen: data.users[0].last_seen,
+            name: data.users[0].name,
+            profileImage: data.users[0].profile_image,
+          });
+        }
+      },
+    });
+  const { loading: userBadgeCountLoading } =
+    useQuery<FetchUserBadgesCountResponse>(FETCH_USER_BADGES_COUNT, {
+      variables: {
+        userId: user.uid,
+      },
+      onCompleted: (data) => {
+        if (data.user_coding_badges_aggregate.aggregate.count) {
+          setUserBadgeCount(data.user_coding_badges_aggregate.aggregate.count);
+        }
+      },
+    });
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        {userProfileData && (
+          <h1 className="text-3xl font-bold">{userProfileData.name}</h1>
+        )}
+      </div>
+      {userProfileLoading ? (
+        <div>Loading...</div>
+      ) : (
+        <div className="grid grid-cols-1 mt-12 sm:grid-cols-8">
+          <img
+            className="w-32 rounded-full"
+            src={userProfileData.profileImage}
+          />
+          <div className="col-span-2 mt-2 ml-2">
+            <div className="flex mt-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-6 h-6 text-charmander"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zM12.75 6a.75.75 0 00-1.5 0v6c0 .414.336.75.75.75h4.5a.75.75 0 000-1.5h-3.75V6z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+
+              <span className="ml-2 text-lg">
+                {userProfileData.createdAt
+                  ? "Joined " +
+                    format(new Date(userProfileData.createdAt), "MMMM yyyy")
+                  : userProfileData.createdAt}
+              </span>
+            </div>
+            <p className="flex text-lg">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-6 h-6 text-rattata"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2.25a4.49 4.49 0 00-3.397 1.549 4.49 4.49 0 00-3.497 1.307 4.49 4.49 0 00-1.307 3.497A4.49 4.49 0 002.25 12c0 1.357.6 2.573 1.548 3.397a4.491 4.491 0 001.307 3.498A4.49 4.49 0 008.603 20.2 4.49 4.49 0 0012 21.75a4.49 4.49 0 003.397-1.549 4.491 4.491 0 003.497-1.307 4.491 4.491 0 001.307-3.497A4.49 4.49 0 0021.75 12a4.49 4.49 0 00-1.548-3.397 4.491 4.491 0 00-1.307-3.497 4.49 4.49 0 00-3.498-1.307A4.49 4.49 0 0012 2.25zm3.059 8.062a.75.75 0 10-.993-1.124 12.785 12.785 0 00-3.209 4.358L9.53 12.22a.75.75 0 00-1.06 1.06l2.135 2.136a.75.75 0 001.24-.289 11.264 11.264 0 013.214-4.815z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+
+              <span className="ml-2">{userBadgeCount}/49 Unlocked Badges</span>
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/coding/ProfileHeaderComponent.tsx
+++ b/components/coding/ProfileHeaderComponent.tsx
@@ -69,13 +69,15 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
       {userProfileLoading ? (
         <div>Loading...</div>
       ) : (
-        <div className="grid grid-cols-1 mt-12 sm:grid-cols-8">
+        <div className="grid grid-cols-4 col-span-5 mt-4 md:grid-cols-8">
           <img
-            className="w-32 rounded-full"
+            className="w-36 mt-6 mr-2 rounded-full"
             src={userProfileData.profileImage}
           />
-          <div className="col-span-2 mt-2 ml-2">
-            <h1 className="text-3xl font-bold mt-2">{userProfileData.name}</h1>
+          <div className="col-span-3 mt-2 ml-2">
+            <h1 className="text-2xl font-bold mt-2 md:text-4xl md:mt-6">
+              {userProfileData.name}
+            </h1>
             <div className="flex mt-4">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -90,14 +92,14 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
                 />
               </svg>
 
-              <span className="ml-2 text-lg">
+              <span className="ml-2 text-md md:text-xl">
                 {userProfileData.createdAt
                   ? "Joined " +
                     format(new Date(userProfileData.createdAt), "MMMM yyyy")
                   : userProfileData.createdAt}
               </span>
             </div>
-            <p className="flex text-lg">
+            <p className="flex text-md md:text-xl">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"

--- a/components/coding/ProfileHeaderComponent.tsx
+++ b/components/coding/ProfileHeaderComponent.tsx
@@ -92,14 +92,14 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
                 />
               </svg>
 
-              <span className="ml-2 text-md md:text-xl">
+              <span className="ml-2 text-md md:text-lg">
                 {userProfileData.createdAt
                   ? "Joined " +
                     format(new Date(userProfileData.createdAt), "MMMM yyyy")
                   : userProfileData.createdAt}
               </span>
             </div>
-            <p className="flex text-md md:text-xl">
+            <p className="flex text-md md:text-lg">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"

--- a/components/coding/ProfileHeaderComponent.tsx
+++ b/components/coding/ProfileHeaderComponent.tsx
@@ -66,11 +66,6 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
 
   return (
     <>
-      <div className="flex items-center justify-between">
-        {userProfileData && (
-          <h1 className="text-3xl font-bold">{userProfileData.name}</h1>
-        )}
-      </div>
       {userProfileLoading ? (
         <div>Loading...</div>
       ) : (
@@ -80,6 +75,7 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
             src={userProfileData.profileImage}
           />
           <div className="col-span-2 mt-2 ml-2">
+            <h1 className="text-3xl font-bold mt-2">{userProfileData.name}</h1>
             <div className="flex mt-4">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -116,7 +112,7 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
               </svg>
 
               <span className="ml-2">
-                {userBadgeCount}/{badgeCount} Unlocked Badges
+                {userBadgeCount}/{badgeCount} Badges
               </span>
             </p>
           </div>

--- a/components/coding/ProfileHeaderComponent.tsx
+++ b/components/coding/ProfileHeaderComponent.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@apollo/client";
 import { format } from "date-fns";
 import React, { useState } from "react";
+
+import { FETCH_TOTAL_USER_BADGES_COUNT } from "../../graphql/fetchTotalUserBadgesCount";
 import {
   FetchUserBadgesCountResponse,
   FETCH_USER_BADGES_COUNT,
@@ -21,6 +23,7 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
     useState<UserProfileData>(Object);
 
   const [userBadgeCount, setUserBadgeCount] = useState<number>(0);
+  const [badgeCount, setTotalBadgeCount] = useState<number>(0);
 
   const { loading: userProfileLoading } =
     useQuery<FetchUserProfileDataResponse>(FETCH_USER_PROFILE_DATA, {
@@ -48,6 +51,15 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
       onCompleted: (data) => {
         if (data.user_coding_badges_aggregate.aggregate.count) {
           setUserBadgeCount(data.user_coding_badges_aggregate.aggregate.count);
+        }
+      },
+    });
+
+  const { loading: totalUserBadgeCountLoading } =
+    useQuery<FetchUserBadgesCountResponse>(FETCH_TOTAL_USER_BADGES_COUNT, {
+      onCompleted: (data) => {
+        if (data.user_coding_badges_aggregate.aggregate.count) {
+          setTotalBadgeCount(data.user_coding_badges_aggregate.aggregate.count);
         }
       },
     });
@@ -103,7 +115,9 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
                 />
               </svg>
 
-              <span className="ml-2">{userBadgeCount}/49 Unlocked Badges</span>
+              <span className="ml-2">
+                {userBadgeCount}/{badgeCount} Unlocked Badges
+              </span>
             </p>
           </div>
         </div>

--- a/graphql/fetchTotalUserBadgesCount.ts
+++ b/graphql/fetchTotalUserBadgesCount.ts
@@ -1,0 +1,11 @@
+import { gql } from "@apollo/client";
+
+export const FETCH_TOTAL_USER_BADGES_COUNT = gql`
+query fetchTotalUserBadgesCount {
+    user_coding_badges_aggregate {
+      aggregate {
+        count(columns: badgeId)
+      }
+    }
+  }
+`;

--- a/pages/profile/v2/[slug].tsx
+++ b/pages/profile/v2/[slug].tsx
@@ -1,0 +1,85 @@
+import { ApolloClient, InMemoryCache } from "@apollo/client";
+import ProfileGoalsSection from "../../../components/coding/ProfileGoalsSection";
+import ProfileHeaderComponent from "../../../components/coding/ProfileHeaderComponent";
+import ProjectsSection from "../../../components/coding/ProjectsSection";
+import UserProfileSection from "../../../components/coding/UserProfileSection";
+import LandingNavbar from "../../../components/LandingNavbar";
+import BadgesSection from "../../../components/profile/BadgesSection";
+import { FETCH_RECENT_USERS } from "../../../graphql/fetchRecentUsers";
+import { FETCH_USER } from "../../../graphql/fetchUser";
+
+export default function ExternalUserProfile({ slug, uid }) {
+  const user = {
+    uid,
+  };
+  return (
+    <div>
+      <LandingNavbar />
+      <div className="flex flex-col p-8 m-4 overflow-auto bg-scroll bg-slate-50 sm:m-auto max-w-7xl dark:bg-slate-800 dark:text-white">
+        <ProfileHeaderComponent user={user} />
+
+        <h2 className="text-lg font-bold mt-14 mb-9">Projects</h2>
+
+        <div className="grid grid-cols-1 mb-16 sm:grid-cols-3">
+          <ProjectsSection user={user} />
+        </div>
+
+        <h2 className="text-lg font-bold mt-14 mb-9">Goals</h2>
+
+        <div className="grid grid-cols-1 mb-16 sm:grid-cols-3">
+          <ProfileGoalsSection user={user} />
+        </div>
+
+        <h2 className="text-lg font-bold mb-9">Achievements</h2>
+        <BadgesSection user={user} />
+      </div>
+    </div>
+  );
+}
+
+ExternalUserProfile.getLayout = function getLayout(page) {
+  return <div>{page}</div>;
+};
+
+export async function getStaticProps({ params }) {
+  const client = new ApolloClient({
+    uri: "https://talented-duckling-40.hasura.app/v1/graphql/",
+    cache: new InMemoryCache(),
+  });
+  const { data } = await client.query({
+    query: FETCH_USER,
+    variables: {
+      link: params.slug,
+    },
+  });
+
+  console.log(params.slug, data.users[0].id);
+
+  return {
+    props: {
+      slug: params.slug,
+      uid: data.users[0].id,
+    },
+  };
+}
+
+export async function getStaticPaths() {
+  const client = new ApolloClient({
+    uri: "https://talented-duckling-40.hasura.app/v1/graphql/",
+    cache: new InMemoryCache(),
+  });
+  const { data } = await client.query({
+    query: FETCH_RECENT_USERS,
+  });
+
+  const ids = data.users
+    .map((user) => {
+      return { params: { slug: user["link"] } };
+    })
+    .filter((user) => user.params.slug !== null);
+
+  return {
+    paths: ids,
+    fallback: true,
+  };
+}

--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import ProfileGoalsSection from "../../../components/coding/ProfileGoalsSection";
+import ProfileHeaderComponent from "../../../components/coding/ProfileHeaderComponent";
+import ProjectsSection from "../../../components/coding/ProjectsSection";
+import UserProfileSection from "../../../components/coding/UserProfileSection";
+import BadgesSection from "../../../components/profile/BadgesSection";
+import { useAuth } from "../../../lib/authContext";
+
+export default function Profile(props) {
+  const { user } = useAuth();
+
+  return (
+    <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
+      <ProfileHeaderComponent user={user} />
+
+      <h2 className="text-lg font-bold mt-14 mb-9">Projects</h2>
+
+      <div className="grid grid-cols-1 mb-4 sm:grid-cols-3">
+        <ProjectsSection user={user} />
+      </div>
+
+      <h2 className="text-lg font-bold mt-14 mb-9">Goals</h2>
+
+      <div className="grid grid-cols-1 mb-16 sm:grid-cols-3">
+        <ProfileGoalsSection user={user} />
+      </div>
+
+      <h2 className="text-lg font-bold mb-9">Achievements</h2>
+      <BadgesSection user={user} />
+    </div>
+  );
+}
+
+Profile.auth = true;


### PR DESCRIPTION
1. created v2 page in order to visualize work
2. created ProfileHeaderComponent to look like Figma outline
3. created query to display total badges possible to fit Figma sketch
4. worked off the mobile view and then added the tailwind md styling to make things bigger for the regular computer screen

![Screen Shot 2022-12-02 at 3 31 38 PM](https://user-images.githubusercontent.com/111075855/205392804-90294999-7a92-4ec7-b20b-e4678d1c6184.png)
![Screen Shot 2022-12-02 at 3 33 01 PM](https://user-images.githubusercontent.com/111075855/205392834-40ef9982-99c8-4e55-bb69-07a3b8825dd0.png)
