### PR TITLE
created a fix for if there is a long title

### DIFF
--- a/components/coding/profileV2/AssignmentSectionComponent.tsx
+++ b/components/coding/profileV2/AssignmentSectionComponent.tsx
@@ -16,6 +16,30 @@ import {
 import { useAuth } from "../../../lib/authContext";
 import ExpandableContainer from "../ExpandableContainer";
 
+export const returnWrapStyling = (
+  assignment: UserAssignmentSubmissionsData
+) => {
+  let wrapStyle = "";
+  if (assignment.coding_assignment.assignment_name.length >= 3) {
+    wrapStyle = "truncate";
+  } else {
+    null;
+  }
+  return wrapStyle;
+};
+
+export const returnParentStyling = (
+  assignment: UserAssignmentSubmissionsData
+) => {
+  let parentStyle = "";
+  if (assignment.coding_assignment.assignment_name.length >= 8) {
+    parentStyle = "w-[100px] hover:w-full";
+  } else {
+    null;
+  }
+  return parentStyle;
+};
+
 export type AssignmentSectionComponentProps = {};
 
 export default function AssignmentsSection({}: AssignmentSectionComponentProps) {
@@ -36,13 +60,14 @@ export default function AssignmentsSection({}: AssignmentSectionComponentProps) 
         },
       }
     );
+
   return (
     <ExpandableContainer open={true} title={""}>
       <div>
         {userAssignments.length > 0 && (
-          <div className="grid grid-cols-5 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
-            <p className="col-span-2 md:col-span-6">Assignment</p>
-            <p className="col-span-2 font-semibold md:col-span-2">Status</p>
+          <div className="grid grid-cols-9 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
+            <p className="col-span-4 md:col-span-6">Assignment</p>
+            <p className="col-span-3 font-semibold md:col-span-2">Status</p>
           </div>
         )}
 
@@ -56,12 +81,18 @@ export default function AssignmentsSection({}: AssignmentSectionComponentProps) 
           userAssignments.map((assignment, index) => {
             return (
               <div
-                className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${assignment}`}
+                className={`grid grid-cols-7 my-2 text-sm text-left md:grid-cols-12 md:text-lg md:place-items-center  ${assignment}`}
               >
-                <p className="col-span-1">{index + 1}.</p>
-                <p className="col-span-1 md:col-span-4">
-                  {assignment.coding_assignment.assignment_name}
-                </p>
+                <p className="place-item-left col-span-1">{index + 1}.</p>
+                <div
+                  className={`col-span-3 md:col-span-4 ${returnParentStyling(
+                    assignment
+                  )}`}
+                >
+                  <p className={` ${returnWrapStyling(assignment)}`}>
+                    {assignment.coding_assignment.assignment_name}
+                  </p>
+                </div>
                 <p className="col-span-2 md:block md:col-span-4">
                   {assignment.submission_link ? (
                     assignment.review_link === null ? (
@@ -73,9 +104,11 @@ export default function AssignmentsSection({}: AssignmentSectionComponentProps) 
                     <XIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
                   )}
                 </p>
-                <Link href={assignment.coding_assignment.assignment_link}>
-                  <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-                </Link>
+                <div className="col-span-1">
+                  <Link href={assignment.coding_assignment.assignment_link}>
+                    <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+                  </Link>
+                </div>
               </div>
             );
           })


### PR DESCRIPTION
1. created a parent div that sets the width and then on the child <p> the text truncates if it's longer than the set width
2. hover is set to show the entire title
3. this does not apply if over 8 characters

also readjusted columns so that they are better aligned
![Screen Shot 2022-12-14 at 3 57 09 PM](https://user-images.githubusercontent.com/111075855/207745697-7978676e-84df-4c8a-911d-d1a6ec7f1afb.png)
(1. new styling for mobile view)
![Screen Shot 2022-12-14 at 3 55 05 PM](https://user-images.githubusercontent.com/111075855/207745777-581a49b4-ffa0-4875-ac22-bfdcc4cef356.png)
(2. this is the view if the assignment title is very long -- truncated)
![Screen Shot 2022-12-14 at 3 54 54 PM](https://user-images.githubusercontent.com/111075855/207745827-5114d097-5d43-4060-904e-3a0336ca0535.png)
(3. this is the view when you hover over the title -- more is shown but it still cuts off when it goes beyond a certain point)
![Screen Shot 2022-12-14 at 3 56 50 PM](https://user-images.githubusercontent.com/111075855/207746092-b02a701c-3f8d-4d5a-8976-2b50d8a613e6.png)
(4. this is the current view with the "template" shorter assignment name in full screen view)

