### PR TITLE
fix bug for skillRatings when user has no skills in DB

### DIFF
--- a/graphql/fetchSkillsAndRatings.ts
+++ b/graphql/fetchSkillsAndRatings.ts
@@ -1,23 +1,23 @@
 import { gql } from "@apollo/client";
 
 export const FETCH_SKILLS_AND_RATINGS = gql`
-query fetchAllSkillsAndExistingRatings($userId: String = "") {
-    intro_course_skills {
+query fetchAllSkillsAndExistingRatings($userId: String = "", $_eq: String = "") {
+  intro_course_skills {
+    id
+    name
+    intro_course_skills_users(where: {userId: {_eq: $userId}}) {
       id
-      name
-      intro_course_skills_users {
-        id
+    }
+    intro_course_unit {
+      title
+    }
+    intro_course_skills_users_aggregate(where: {userId: {_eq: $userId}}) {
+      nodes {
+        studentRating
       }
-      intro_course_unit {
-        title
-      }
-      intro_course_skills_users_aggregate(where: { userId: { _eq: $userId } }) {
-        nodes {
-          studentRating
-          }
-        }
-      }
-    }  
+    }
+  }
+}
 `;
 
 


### PR DESCRIPTION
this should fix the bug. it was pulling the userSkillIds already in the database and therefore the upsert query didn't work and would just modify the records that already existed.

Now when the upsert query is called all records appear in the database for that user.
![Screen Shot 2023-01-06 at 2 13 38 PM](https://user-images.githubusercontent.com/111075855/211092499-a8d732b8-4cff-4d95-88a0-6c04c4d49806.png)
partial screenshot of database populated with new userId records as desired:
![Screen Shot 2023-01-06 at 2 17 22 PM](https://user-images.githubusercontent.com/111075855/211092686-5a49e7b3-a784-4219-afca-4f813bca8452.png)


