### PR TITLE
Redesign expandable container closer to figma sketches

### DIFF
--- a/components/coding/ExpandableContainer.tsx
+++ b/components/coding/ExpandableContainer.tsx
@@ -39,7 +39,7 @@ const ExpandableContainer: React.FC<ExpandableContainerProps> = ({
                 <MinusCircleIcon className="w-6 h-6 cursor-pointer hover:text-yellow-600" />
               )}
             </button>
-            <h6 className="text-3xl font-bold pb-2 md:text-4xl mt-3">
+            <h6 className="text-2xl font-bold pb-2 md:text-3xl mt-3">
               {title}
             </h6>
           </div>

--- a/components/coding/ExpandableContainer.tsx
+++ b/components/coding/ExpandableContainer.tsx
@@ -21,9 +21,13 @@ const ExpandableContainer: React.FC<ExpandableContainerProps> = ({
 
   return (
     <>
-      <div>
+      <div
+        className={`border-4 border-gray-900 rounded-lg ${
+          isOpen ? "shadow-lg shadow-gray-900" : ""
+        } `}
+      >
         <div>
-          <div className="p-2 border-bottom flex float left">
+          <div className="flex flex-row items-center p-4 space-x-2">
             <button
               className="mr-2"
               type="button"
@@ -35,7 +39,9 @@ const ExpandableContainer: React.FC<ExpandableContainerProps> = ({
                 <MinusCircleIcon className="w-6 h-6 cursor-pointer hover:text-yellow-600" />
               )}
             </button>
-            <h6 className="">{title}</h6>
+            <h6 className="text-3xl font-bold pb-2 md:text-4xl mt-3">
+              {title}
+            </h6>
           </div>
         </div>
 

--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -32,56 +32,49 @@ export default function GoalsSection({
   inProfile,
 }: GoalsSectionProps) {
   return userGoals.length > 0 ? (
-    <ExpandableContainer open={true} title={"Goals"}>
-      <div className="dark:text-white">
-        {userGoals.length > 0 && (
-          <div className="grid grid-cols-5 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
-            <p className="font-semibold">{sectionName}</p>
-            <p className="col-span-2 md:col-span-4">Goal</p>
-            <p className="hidden md:block md:col-span-2">Date Added</p>
-            <p className="font-semibold md:col-span-2">Target Date</p>
-            <p className="hidden md:block md:col-span-2">Days Remaining</p>
-          </div>
-        )}
+    <div className="dark:text-white">
+      {userGoals.length > 0 && (
+        <div className="grid grid-cols-5 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
+          <p className="font-semibold">{sectionName}</p>
+          <p className="col-span-2 md:col-span-4">Goal</p>
+          <p className="hidden md:block md:col-span-2">Date Added</p>
+          <p className="font-semibold md:col-span-2">Target Date</p>
+          <p className="hidden md:block md:col-span-2">Days Remaining</p>
+        </div>
+      )}
 
-        {userGoals.map((goal, index) => {
-          return (
-            <div
-              className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${returnGoalStyle(
-                goal
-              )}`}
-            >
-              <p>{index + 1}.</p>
-              <p className="col-span-2 md:col-span-4">{goal.goalName}</p>
-              <p className="hidden md:block md:col-span-2">
-                {format(new Date(goal.createdAt), "MM/dd/yyyy")}
-              </p>
-              <p className="hidden md:block col-span-1 md:col-span-2">
-                {format(new Date(goal.targetDate), "MM/dd/yyyy")}
-              </p>
-              <p className="md:hidden col-span-1">
-                {format(new Date(goal.targetDate), "MM/dd")}
-              </p>
-              <p className="hidden md:block md:col-span-2">
-                {differenceInCalendarDays(
-                  new Date(goal.targetDate),
-                  new Date()
-                )}
-              </p>
-              <Link href={"/goals/" + goal.id}>
-                <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-              </Link>
-            </div>
-          );
-        })}
-      </div>
-    </ExpandableContainer>
+      {userGoals.map((goal, index) => {
+        return (
+          <div
+            className={`grid grid-cols-5 my-2 text-sm text-center md:grid-cols-12 md:text-lg place-items-center ${returnGoalStyle(
+              goal
+            )}`}
+          >
+            <p>{index + 1}.</p>
+            <p className="col-span-2 md:col-span-4">{goal.goalName}</p>
+            <p className="hidden md:block md:col-span-2">
+              {format(new Date(goal.createdAt), "MM/dd/yyyy")}
+            </p>
+            <p className="hidden md:block col-span-1 md:col-span-2">
+              {format(new Date(goal.targetDate), "MM/dd/yyyy")}
+            </p>
+            <p className="md:hidden col-span-1">
+              {format(new Date(goal.targetDate), "MM/dd")}
+            </p>
+            <p className="hidden md:block md:col-span-2">
+              {differenceInCalendarDays(new Date(goal.targetDate), new Date())}
+            </p>
+            <Link href={"/goals/" + goal.id}>
+              <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+            </Link>
+          </div>
+        );
+      })}
+    </div>
   ) : userGoals.length <= 0 && inProfile ? (
-    <ExpandableContainer open={true} title={"Goals"}>
-      <div className="col-span-3 p-8 mb-8 text-center shadow-md bg-slate-300 dark:bg-slate-900">
-        Click on the "Goals" tab on the sidebar to get ahead by creating and
-        tracking your goals!
-      </div>
-    </ExpandableContainer>
+    <div className="col-span-3 p-8 mb-8 text-center shadow-md bg-slate-300 dark:bg-slate-900">
+      Click on the "Goals" tab on the sidebar to get ahead by creating and
+      tracking your goals!
+    </div>
   ) : userGoals.length <= 0 && !inProfile ? null : null;
 }

--- a/components/coding/GoalsSectionComponent.tsx
+++ b/components/coding/GoalsSectionComponent.tsx
@@ -32,7 +32,7 @@ export default function GoalsSection({
   inProfile,
 }: GoalsSectionProps) {
   return userGoals.length > 0 ? (
-    <ExpandableContainer open={true} title={""}>
+    <ExpandableContainer open={true} title={"Goals"}>
       <div className="dark:text-white">
         {userGoals.length > 0 && (
           <div className="grid grid-cols-5 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
@@ -77,7 +77,7 @@ export default function GoalsSection({
       </div>
     </ExpandableContainer>
   ) : userGoals.length <= 0 && inProfile ? (
-    <ExpandableContainer open={true} title={""}>
+    <ExpandableContainer open={true} title={"Goals"}>
       <div className="col-span-3 p-8 mb-8 text-center shadow-md bg-slate-300 dark:bg-slate-900">
         Click on the "Goals" tab on the sidebar to get ahead by creating and
         tracking your goals!

--- a/components/coding/SkillRatingsComponent.tsx
+++ b/components/coding/SkillRatingsComponent.tsx
@@ -43,8 +43,8 @@ export default function SkillRatingsComponent(props) {
   });
 
   return (
-    <div className="flex flex-row overflow-auto-bg-scroll">
-      <ExpandableContainer open={true} title={""}>
+    <div className="overflow-auto-bg-scroll">
+      <ExpandableContainer open={true} title={"Skill Ratings"}>
         <div className="flex flex-col p-4 m-4">
           {skillRatings && <SkillSection skillSection={skillRatings} />}
         </div>

--- a/components/coding/SkillRatingsComponent.tsx
+++ b/components/coding/SkillRatingsComponent.tsx
@@ -44,23 +44,21 @@ export default function SkillRatingsComponent(props) {
 
   return (
     <div className="overflow-auto-bg-scroll">
-      <ExpandableContainer open={true} title={"Skill Ratings"}>
-        <div className="flex flex-col p-4 m-4">
-          {skillRatings && <SkillSection skillSection={skillRatings} />}
-        </div>
-        <div className="flex float-right p-4 mr-8 mt-8">
-          <Button
-            label="Save"
-            onClick={() =>
-              saveSkillRatings({
-                variables: {
-                  objects: transformSkillRatingForDB(skillRatings, user),
-                },
-              })
-            }
-          />
-        </div>
-      </ExpandableContainer>
+      <div className="flex flex-col p-4 m-4">
+        {skillRatings && <SkillSection skillSection={skillRatings} />}
+      </div>
+      <div className="flex float-right p-4 mr-8 mt-8">
+        <Button
+          label="Save"
+          onClick={() =>
+            saveSkillRatings({
+              variables: {
+                objects: transformSkillRatingForDB(skillRatings, user),
+              },
+            })
+          }
+        />
+      </div>
     </div>
   );
 }

--- a/components/coding/profileV2/AchievementComponent.tsx
+++ b/components/coding/profileV2/AchievementComponent.tsx
@@ -3,6 +3,8 @@ import ExpandableContainer from "../ExpandableContainer";
 import { PencilAltIcon } from "@heroicons/react/outline";
 import { User } from "../../../graphql/fetchUserProfile";
 import { transformUserBadgeData } from "./AchievementTransformData";
+import { useQuery } from "@apollo/client";
+import { FETCH_CODING_BADGES } from "../../../graphql/coding/userBadges/fetchUserBadges";
 
 export type BadgesSectionProps = {
   data: User;
@@ -21,7 +23,12 @@ export type codingBadges = {
   isAwarded: boolean;
 };
 export type unit = unitProps[];
-const AcheivementComponent = ({ data }) => {
+const AcheivementComponent = ({ user }) => {
+  const { data } = useQuery(FETCH_CODING_BADGES, {
+    variables: {
+      userId: user.uid,
+    },
+  });
   const [transformedData, setTransformedData] = useState([]);
   const [editMode, setEditMode] = useState(false);
   const handleBadgeClick = (inputBadge: codingBadges) => {
@@ -55,54 +62,29 @@ const AcheivementComponent = ({ data }) => {
   }, [data]);
 
   return (
-      <div className="p-4 shadow-md bg-slate-300 dark:bg-transparent">
-        <div className="flex justify-end w-full mb-4">
-          <button
-            onClick={() => setEditMode(!editMode)}
-            className="w-5 h-5 cursor-pointer hover:text-yellow-600"
-          >
-            {editMode ? (
-              <PencilAltIcon className="w-5 h-5 text-yellow-600 cursor-pointer" />
-            ) : (
-              <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-            )}
-          </button>
-        </div>
-        <div>
-          {transformedData.map((unit) => {
-            if (unit.codingBadges.length > 0) {
-              return (
-                <div className="m-4">
-                  <UnitBadgeSection
-                    unit={unit}
-                    editMode={editMode}
-                    handleBadgeClick={handleBadgeClick}
-                  />
-                </div>
-                <div>
-                  <div className="grid grid-cols-3 mb-8 text-base sm:mb-0  ">
-                    {unit.codingBadges.map((badge) => (
-                      <div className="flex flex-col items-center justify-center">
-                        <button
-                          disabled={!editMode}
-                          onClick={() => handleBadgeClick(badge)}
-                        >
-                          {/* <button onClick={() => handleBadgeClick(badge)}> */}
-                          <img
-                            className="w-28"
-                            src={
-                              badge.isAwarded
-                                ? "/images/profile/achievement-badge-active.svg"
-                                : "/images/profile/achievement-badge.svg"
-                            }
-                          />
-                        </button>
-                        <p className="text-base">{unit.unitTitle}</p>
-                        <p className="mb-8 text-base sm:mb-0">{badge.title}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+    <div className="sm:shadow-md sm:p-4 sm:bg-slate-300 dark:bg-transparent">
+      <div className="flex justify-end w-full mb-4">
+        <button
+          onClick={() => setEditMode(!editMode)}
+          className="w-5 h-5 cursor-pointer hover:text-yellow-600"
+        >
+          {editMode ? (
+            <PencilAltIcon className="w-5 h-5 text-yellow-600 cursor-pointer" />
+          ) : (
+            <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+          )}
+        </button>
+      </div>
+      <div>
+        {transformedData.map((unit) => {
+          if (unit.codingBadges.length > 0) {
+            return (
+              <div className="mb-4 sm:m-4">
+                <UnitBadgeSection
+                  unit={unit}
+                  editMode={editMode}
+                  handleBadgeClick={handleBadgeClick}
+                />
               </div>
             );
           }
@@ -123,14 +105,14 @@ function UnitBadgeSection({ unit, editMode, handleBadgeClick }) {
 
   return (
     <div>
-      <div className="grid grid-cols-2 sm:grid-cols-1">
+      <div className="grid grid-cols-1">
         <div
           className="flex p-4 cursor-pointer bg-slate-800 hover:bg-slate-700 group"
           onClick={() => setIsOpen(!isOpen)}
         >
           <img
             src={unit.image}
-            className="object-cover w-24 h-24 bg-red-300 rounded-lg group-hover:scale-110"
+            className="object-cover w-24 h-24 transition-all transform bg-red-300 rounded-lg group-hover:scale-110"
           />
           <div className="flex flex-col justify-center px-4">
             <h3 className="text-xl font-bold text-white">{unit.unitTitle}</h3>
@@ -141,7 +123,7 @@ function UnitBadgeSection({ unit, editMode, handleBadgeClick }) {
         </div>
       </div>
       {isOpen && (
-        <div className="grid grid-cols-3 mb-8 text-base bg-slate-800 sm:mb-0 ">
+        <div className="grid grid-cols-1 mb-8 text-base sm:grid-cols-3 bg-slate-800 sm:mb-0 ">
           {unit.codingBadges.map((badge) => (
             <div className="m-4">
               <CodingBadge
@@ -159,7 +141,6 @@ function UnitBadgeSection({ unit, editMode, handleBadgeClick }) {
 }
 
 function CodingBadge({ disabled, handleBadgeClick, badge, unit }) {
-
   return (
     <div className="flex flex-col items-center justify-center h-full p-4 text-white bg-slate-600 border-slate-300">
       <button
@@ -169,7 +150,7 @@ function CodingBadge({ disabled, handleBadgeClick, badge, unit }) {
       >
         {/* <button onClick={() => handleBadgeClick(badge)}> */}
         <img
-          className="w-28 h-28"
+          className="transition-all transform border-4 rounded-full shadow-lg w-28 h-28 hover:scale-110"
           src={
             badge.isAwarded
               ? badge.image
@@ -179,8 +160,8 @@ function CodingBadge({ disabled, handleBadgeClick, badge, unit }) {
           }
         />
       </button>
-      <div className="flex flex-col items-center justify-center h-full">
-        <p className="h-full mb-8 text-base sm:mb-0">{badge.title}</p>
+      <div className="flex flex-col items-center justify-center h-full mt-4 ">
+        <p className="h-full text-base sm:mb-0">{badge.title}</p>
       </div>
     </div>
   );

--- a/components/coding/profileV2/AchievementComponent.tsx
+++ b/components/coding/profileV2/AchievementComponent.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import ExpandableContainer from "../ExpandableContainer";
 import { PencilAltIcon } from "@heroicons/react/outline";
 import { User } from "../../../graphql/fetchUserProfile";
 import { transformUserBadgeData } from "./AchievementTransformData";

--- a/components/coding/profileV2/AchievementComponent.tsx
+++ b/components/coding/profileV2/AchievementComponent.tsx
@@ -55,7 +55,7 @@ const AcheivementComponent = ({ data }) => {
   }, [data]);
 
   return (
-    <ExpandableContainer open={true} title={""}>
+    <ExpandableContainer open={true} title={"Achievements"}>
       <div className="p-4 shadow-md bg-slate-300 dark:bg-transparent">
         <div className="absolute px-16 right-1">
           <button

--- a/components/coding/profileV2/AchievementComponent.tsx
+++ b/components/coding/profileV2/AchievementComponent.tsx
@@ -55,63 +55,59 @@ const AcheivementComponent = ({ data }) => {
   }, [data]);
 
   return (
-    <ExpandableContainer open={true} title={"Achievements"}>
-      <div className="p-4 shadow-md bg-slate-300 dark:bg-transparent">
-        <div className="absolute px-16 right-1">
-          <button
-            onClick={() => setEditMode(!editMode)}
-            className="w-5 h-5 cursor-pointer hover:text-yellow-600"
-          >
-            {editMode ? (
-              <PencilAltIcon className="w-5 h-5 cursor-pointer text-yellow-600" />
-            ) : (
-              <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-            )}
-          </button>
-        </div>
-        <div>
-          {transformedData.map((unit) => {
-            if (unit.codingBadges.length > 0) {
-              return (
-                <div>
-                  <div className="grid grid-cols-2 sm:grid-cols-6">
-                    <div className="py-4 text-center text-gray-400 bg-gray-200 rounded-full">
-                      {unit.unitTitle}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="grid grid-cols-3 mb-8 text-base sm:mb-0  ">
-                      {unit.codingBadges.map((badge) => (
-                        <div className="flex flex-col items-center justify-center">
-                          <button
-                            disabled={!editMode}
-                            onClick={() => handleBadgeClick(badge)}
-                          >
-                            {/* <button onClick={() => handleBadgeClick(badge)}> */}
-                            <img
-                              className="w-28"
-                              src={
-                                badge.isAwarded
-                                  ? "/images/profile/achievement-badge-active.svg"
-                                  : "/images/profile/achievement-badge.svg"
-                              }
-                            />
-                          </button>
-                          <p className="text-base">{unit.unitTitle}</p>
-                          <p className="mb-8 text-base sm:mb-0">
-                            {badge.title}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
+    <div className="p-4 shadow-md bg-slate-300 dark:bg-transparent">
+      <div className="absolute px-16 right-1">
+        <button
+          onClick={() => setEditMode(!editMode)}
+          className="w-5 h-5 cursor-pointer hover:text-yellow-600"
+        >
+          {editMode ? (
+            <PencilAltIcon className="w-5 h-5 cursor-pointer text-yellow-600" />
+          ) : (
+            <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+          )}
+        </button>
+      </div>
+      <div>
+        {transformedData.map((unit) => {
+          if (unit.codingBadges.length > 0) {
+            return (
+              <div>
+                <div className="grid grid-cols-2 sm:grid-cols-6">
+                  <div className="py-4 text-center text-gray-400 bg-gray-200 rounded-full">
+                    {unit.unitTitle}
                   </div>
                 </div>
-              );
-            }
-          })}
-        </div>
+                <div>
+                  <div className="grid grid-cols-3 mb-8 text-base sm:mb-0  ">
+                    {unit.codingBadges.map((badge) => (
+                      <div className="flex flex-col items-center justify-center">
+                        <button
+                          disabled={!editMode}
+                          onClick={() => handleBadgeClick(badge)}
+                        >
+                          {/* <button onClick={() => handleBadgeClick(badge)}> */}
+                          <img
+                            className="w-28"
+                            src={
+                              badge.isAwarded
+                                ? "/images/profile/achievement-badge-active.svg"
+                                : "/images/profile/achievement-badge.svg"
+                            }
+                          />
+                        </button>
+                        <p className="text-base">{unit.unitTitle}</p>
+                        <p className="mb-8 text-base sm:mb-0">{badge.title}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+        })}
       </div>
-    </ExpandableContainer>
+    </div>
   );
 };
 

--- a/components/coding/profileV2/AssignmentSectionComponent.tsx
+++ b/components/coding/profileV2/AssignmentSectionComponent.tsx
@@ -59,7 +59,7 @@ export default function AssignmentsSection({}: AssignmentSectionComponentProps) 
     );
 
   return (
-    <ExpandableContainer open={true} title={""}>
+    <ExpandableContainer open={true} title={"Assignments"}>
       <div>
         {userAssignments.length > 0 && (
           <div className="grid grid-cols-9 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">

--- a/components/coding/profileV2/AssignmentSectionComponent.tsx
+++ b/components/coding/profileV2/AssignmentSectionComponent.tsx
@@ -59,58 +59,56 @@ export default function AssignmentsSection({}: AssignmentSectionComponentProps) 
     );
 
   return (
-    <ExpandableContainer open={true} title={"Assignments"}>
-      <div>
-        {userAssignments.length > 0 && (
-          <div className="grid grid-cols-9 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
-            <p className="col-span-4 md:col-span-6">Assignment</p>
-            <p className="col-span-3 font-semibold md:col-span-2">Status</p>
-          </div>
-        )}
+    <div>
+      {userAssignments.length > 0 && (
+        <div className="grid grid-cols-9 text-sm font-semibold text-center border-b-2 md:grid-cols-12 md:text-lg">
+          <p className="col-span-4 md:col-span-6">Assignment</p>
+          <p className="col-span-3 font-semibold md:col-span-2">Status</p>
+        </div>
+      )}
 
-        {userAssignmentsLoading ? (
-          <div>Loading...</div>
-        ) : userAssignments.length === 0 ? (
-          <div className="col-span-3 p-8 text-center shadow-md bg-slate-300 dark:bg-slate-900">
-            No Active Assignments
-          </div>
-        ) : (
-          userAssignments.map((assignment, index) => {
-            return (
+      {userAssignmentsLoading ? (
+        <div>Loading...</div>
+      ) : userAssignments.length === 0 ? (
+        <div className="col-span-3 p-8 text-center shadow-md bg-slate-300 dark:bg-slate-900">
+          No Active Assignments
+        </div>
+      ) : (
+        userAssignments.map((assignment, index) => {
+          return (
+            <div
+              className={`grid grid-cols-7 my-2 text-sm text-left md:grid-cols-12 md:text-lg md:place-items-center  ${assignment}`}
+            >
+              <p className="col-span-1">{index + 1}.</p>
               <div
-                className={`grid grid-cols-7 my-2 text-sm text-left md:grid-cols-12 md:text-lg md:place-items-center  ${assignment}`}
+                className={`col-span-3 md:col-span-4 ${returnParentStyling(
+                  assignment
+                )}`}
               >
-                <p className="col-span-1">{index + 1}.</p>
-                <div
-                  className={`col-span-3 md:col-span-4 ${returnParentStyling(
-                    assignment
-                  )}`}
-                >
-                  <p className={`${returnWrapStyling(assignment)}`}>
-                    {assignment.coding_assignment.assignment_name}
-                  </p>
-                </div>
-                <p className="col-span-2 md:block md:col-span-4">
-                  {assignment.submission_link ? (
-                    assignment.review_link === null ? (
-                      <ClockIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-                    ) : (
-                      <CheckCircleIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-                    )
-                  ) : (
-                    <XIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-                  )}
+                <p className={`${returnWrapStyling(assignment)}`}>
+                  {assignment.coding_assignment.assignment_name}
                 </p>
-                <div className="col-span-1">
-                  <Link href={assignment.coding_assignment.assignment_link}>
-                    <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
-                  </Link>
-                </div>
               </div>
-            );
-          })
-        )}
-      </div>
-    </ExpandableContainer>
+              <p className="col-span-2 md:block md:col-span-4">
+                {assignment.submission_link ? (
+                  assignment.review_link === null ? (
+                    <ClockIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+                  ) : (
+                    <CheckCircleIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+                  )
+                ) : (
+                  <XIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+                )}
+              </p>
+              <div className="col-span-1">
+                <Link href={assignment.coding_assignment.assignment_link}>
+                  <PencilAltIcon className="w-5 h-5 cursor-pointer hover:text-yellow-600" />
+                </Link>
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
   );
 }

--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@apollo/client";
 import { useDispatch, useSelector } from "react-redux";
+import ExpandableContainer from "../../../components/coding/ExpandableContainer";
 import GoalsSectionComponent from "../../../components/coding/GoalsSectionComponent";
 import AchievementComponent from "../../../components/coding/profileV2/AchievementComponent";
 import AssignmentSectionComponent from "../../../components/coding/profileV2/AssignmentSectionComponent";
@@ -40,21 +41,29 @@ export default function Profile(props) {
     <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
       <ProfileHeaderComponent user={user} />
       <div className="grid grid-cols-1 my-9">
-        <AssignmentSectionComponent />
+        <ExpandableContainer open={true} title={"Assignments"}>
+          <AssignmentSectionComponent />{" "}
+        </ExpandableContainer>
       </div>
       <div className="grid grid-cols-1 my-9">
-        <GoalsSectionComponent
-          inProfile={true}
-          userGoals={userGoals
-            .filter((goal) => !goal.isComplete && !goal.isArchived)
-            .slice(0, 3)}
-        />
+        <ExpandableContainer open={true} title={"Goals"}>
+          <GoalsSectionComponent
+            inProfile={true}
+            userGoals={userGoals
+              .filter((goal) => !goal.isComplete && !goal.isArchived)
+              .slice(0, 3)}
+          />
+        </ExpandableContainer>
       </div>
       <div className="grid grid-cols-1 my-9">
-        <SkillRatingsComponent />
+        <ExpandableContainer open={true} title={"Skill Ratings"}>
+          <SkillRatingsComponent />
+        </ExpandableContainer>
       </div>
       <div className="grid grid-cols-1 my-9">
-        <AchievementComponent data={data} />
+        <ExpandableContainer open={false} title={"Achievements"}>
+          <AchievementComponent data={data} />
+        </ExpandableContainer>
       </div>
     </div>
   );

--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -39,16 +39,10 @@ export default function Profile(props) {
   return (
     <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
       <ProfileHeaderComponent user={user} />
-
-      <h2 className="text-lg font-bold mt-14 mb-9">Assignments</h2>
-
-      <div className="grid grid-cols-1 mb-4">
+      <div className="grid grid-cols-1 my-9">
         <AssignmentSectionComponent />
       </div>
-
-      <h2 className="text-lg font-bold mt-14 mb-9">Goals</h2>
-
-      <div className="grid grid-cols-1">
+      <div className="grid grid-cols-1 my-9">
         <GoalsSectionComponent
           inProfile={true}
           userGoals={userGoals
@@ -56,13 +50,12 @@ export default function Profile(props) {
             .slice(0, 3)}
         />
       </div>
-      <h2 className="text-lg font-bold mt-14 mb-9">Skill Ratings</h2>
-      <div className="grid grid-cols-1">
+      <div className="grid grid-cols-1 my-9">
         <SkillRatingsComponent />
       </div>
-
-      <h2 className="text-lg font-bold mb-9">Achievements</h2>
-      <AchievementComponent data={data} />
+      <div className="grid grid-cols-1 my-9">
+        <AchievementComponent data={data} />
+      </div>
     </div>
   );
 }

--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useQuery } from "@apollo/client";
 import { useDispatch, useSelector } from "react-redux";
 import ExpandableContainer from "../../../components/coding/ExpandableContainer";
@@ -13,7 +14,7 @@ import {
 import { useAuth } from "../../../lib/authContext";
 import { userGoalsSelector, setUserGoals } from "../../../redux/userGoalsSlice";
 
-export default function Profile(props) {
+export default function Profile() {
   const { user } = useAuth();
   const dispatch = useDispatch();
   const { userGoals } = useSelector(userGoalsSelector);
@@ -40,12 +41,16 @@ export default function Profile(props) {
       </div>
       <div className="grid">
         <ExpandableContainer open={true} title={"Goals"}>
-          <GoalsSectionComponent
-            inProfile={true}
-            userGoals={userGoals
-              .filter((goal) => !goal.isComplete && !goal.isArchived)
-              .slice(0, 3)}
-          />
+          {userGoalsLoading ? (
+            <div>Loading...</div>
+          ) : (
+            <GoalsSectionComponent
+              inProfile={true}
+              userGoals={userGoals
+                .filter((goal) => !goal.isComplete && !goal.isArchived)
+                .slice(0, 3)}
+            />
+          )}
         </ExpandableContainer>
       </div>
       <div className="grid">

--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -31,14 +31,14 @@ export default function Profile(props) {
   );
 
   return (
-    <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll">
+    <div className="flex flex-col p-4 m-4 overflow-auto bg-scroll space-y-9">
       <ProfileHeaderComponent userId={user.uid} />
-      <div className="grid grid-cols-1 my-9">
+      <div>
         <ExpandableContainer open={true} title={"Assignments"}>
           <AssignmentSectionComponent />{" "}
         </ExpandableContainer>
       </div>
-      <div className="grid grid-cols-1 my-9">
+      <div className="grid">
         <ExpandableContainer open={true} title={"Goals"}>
           <GoalsSectionComponent
             inProfile={true}
@@ -48,12 +48,12 @@ export default function Profile(props) {
           />
         </ExpandableContainer>
       </div>
-      <div className="grid grid-cols-1 my-9">
+      <div className="grid">
         <ExpandableContainer open={true} title={"Skill Ratings"}>
           <SkillRatingsComponent />
         </ExpandableContainer>
       </div>
-      <div className="grid grid-cols-1 my-9">
+      <div className="grid">
         <ExpandableContainer open={true} title={"Achievements"}>
           <AchievementComponent user={user} />
         </ExpandableContainer>

--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -55,7 +55,7 @@ export default function Profile(props) {
         </ExpandableContainer>
       </div>
       <div className="grid grid-cols-1 my-9">
-        <ExpandableContainer open={false} title={"Achievements"}>
+        <ExpandableContainer open={true} title={"Achievements"}>
           <AchievementComponent user={user} />
         </ExpandableContainer>
       </div>


### PR DESCRIPTION
1. added "title" in the expandable container and removed the section header from the individual components.  this allowed me to use a flex flex-row to display the plus/minus icon next to the title.
2. added border and shadowing around the container.
3. adjusted the shadow depending on if it was open or closed.
4. cleaned up some styling and unused tailwind code.
![Screen Shot 2023-01-08 at 8 36 16 AM](https://user-images.githubusercontent.com/111075855/211202328-d23ab6da-c7c8-4a3d-9406-996164e4496b.png)
