### PR TITLE
Swap Achievements and Skillratings

### DIFF
--- a/pages/profile/v2/index.tsx
+++ b/pages/profile/v2/index.tsx
@@ -53,14 +53,15 @@ export default function Profile() {
           )}
         </ExpandableContainer>
       </div>
-      <div className="grid">
-        <ExpandableContainer open={true} title={"Skill Ratings"}>
-          <SkillRatingsComponent />
-        </ExpandableContainer>
-      </div>
+
       <div className="grid">
         <ExpandableContainer open={true} title={"Achievements"}>
           <AchievementComponent userId={user.uid} isEditable={true} />
+        </ExpandableContainer>
+      </div>
+      <div className="grid">
+        <ExpandableContainer open={true} title={"Skill Ratings"}>
+          <SkillRatingsComponent />
         </ExpandableContainer>
       </div>
     </div>


### PR DESCRIPTION
In this small PR, the achievements component and skillratings have swapped places in the new profile. The achievements component is now higher up.