### PR TITLE
Reworking skillRatings for new profile structure

### DIFF
--- a/components/coding/SkillRatingsComponent.tsx
+++ b/components/coding/SkillRatingsComponent.tsx
@@ -1,43 +1,26 @@
-import { useQuery, useMutation } from "@apollo/client";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import {
-  FetchSkillsAndRatings,
-  FETCH_SKILLS_AND_RATINGS,
-} from "../../graphql/fetchSkillsAndRatings";
 import { FETCH_USER_SKILLS_RATINGS } from "../../graphql/fetchUserSkillsRatings";
 import { UPSERT_USER_SKILL_RATINGS } from "../../graphql/upsertUserSkillRatings";
 import { useAuth } from "../../lib/authContext";
-import {
-  transformSkillRatingForDB,
-  transformSkillsAndRatings,
-} from "../../pages/api/skillRatingsFunctions";
-import {
-  skillRatingsSelector,
-  setSkillRatings,
-} from "../../redux/skillRatingsSlice";
+import { transformSkillRatingForDB } from "../../pages/api/skillRatingsFunctions";
+import { SkillRatingsRow } from "../../redux/skillRatingsSlice";
 import SkillRow from "../skillRatings/SkillRow";
 import { Button } from "../ui/Button";
 import React from "react";
+import { useMutation } from "@apollo/client";
+export type SkillRatingsProps = {
+  skillRatings: SkillRatingsRow[];
+  isEditable: boolean;
+};
 
-export default function SkillRatingsComponent(props) {
-  const dispatch = useDispatch();
+export default function SkillRatingsComponent({
+  skillRatings,
+  isEditable,
+}: SkillRatingsProps) {
   const { user } = useAuth();
-  const { skillRatings } = useSelector(skillRatingsSelector);
   const [activeTab, setActiveTab] = useState("");
   const [sections, setSections] = useState<string[]>([]);
   const [haveTabsLoaded, setHaveTabsLoaded] = useState(false);
-
-  const {} = useQuery<FetchSkillsAndRatings>(FETCH_SKILLS_AND_RATINGS, {
-    variables: {
-      userId: user.uid,
-    },
-    onCompleted: (data) => {
-      dispatch(
-        setSkillRatings(transformSkillsAndRatings(data.intro_course_skills))
-      );
-    },
-  });
 
   const [saveSkillRatings] = useMutation(UPSERT_USER_SKILL_RATINGS, {
     refetchQueries: [{ query: FETCH_USER_SKILLS_RATINGS }],
@@ -110,20 +93,23 @@ export default function SkillRatingsComponent(props) {
                   unitName: it.unitName,
                   studentRating: it.studentRating,
                 }}
+                isEditable={isEditable}
               />
             ))}
       </div>
       <div className="p-4">
-        <Button
-          label="Save"
-          onClick={() =>
-            saveSkillRatings({
-              variables: {
-                objects: transformSkillRatingForDB(skillRatings, user),
-              },
-            })
-          }
-        />
+        {isEditable ? (
+          <Button
+            label="Save"
+            onClick={() =>
+              saveSkillRatings({
+                variables: {
+                  objects: transformSkillRatingForDB(skillRatings, user),
+                },
+              })
+            }
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/components/skillRatings/SkillRow.tsx
+++ b/components/skillRatings/SkillRow.tsx
@@ -8,9 +8,10 @@ import SkillRowEmoji from "./SkillRowEmoji";
 
 export type SkillRowProps = {
   skillRow: SkillRatingsRow;
+  isEditable: boolean;
 };
 
-export default function SkillRow({ skillRow }: SkillRowProps) {
+export default function SkillRow({ skillRow, isEditable }: SkillRowProps) {
   const { skillRatings } = useSelector(skillRatingsSelector);
   const index = skillRatings.findIndex(
     (obj) => obj.userSkillId == skillRow.userSkillId
@@ -42,6 +43,7 @@ export default function SkillRow({ skillRow }: SkillRowProps) {
       <SkillRowEmoji
         userSkillId={skillRow.userSkillId}
         studentRating={skillRow.studentRating}
+        isEditable={isEditable}
       />
     </div>
   );

--- a/components/skillRatings/SkillRowEmoji.tsx
+++ b/components/skillRatings/SkillRowEmoji.tsx
@@ -5,9 +5,14 @@ import { updateSkillRatings } from "../../redux/skillRatingsSlice";
 export interface EmojiSliderProps {
   userSkillId: string;
   studentRating: number;
+  isEditable: boolean;
 }
 
-const EmojiSlider = ({ userSkillId, studentRating }: EmojiSliderProps) => {
+const EmojiSlider = ({
+  userSkillId,
+  studentRating,
+  isEditable,
+}: EmojiSliderProps) => {
   const dispatch = useDispatch();
 
   function handleChange(e) {
@@ -22,6 +27,7 @@ const EmojiSlider = ({ userSkillId, studentRating }: EmojiSliderProps) => {
         onChange={handleChange}
         className="w-44"
         value={studentRating}
+        disabled={!isEditable}
       />
     </div>
   );


### PR DESCRIPTION
1. Moved the query to the [userId] slug page to maintain consistency
2. loaded it in skillRatings redux and drilled it down as a prop to children
3. Placed a check in the query to see if the userId == user.uid (logged in user) -- when true set isEditable
4. drilled isEditable down as a prop to children
5. Changed SkillRowEmoji to disable slider if not logged in user
6. Changed SkillRatingsComponent to remove save button if not logged in user.

When I navigate to x/kari (i.e. logged-in user)
![image](https://user-images.githubusercontent.com/111075855/216411649-3e138507-e21a-4f3e-ac93-7b74e0c8fa1d.png)
When I navigate to x/lucky (i.e. not logged-in user)
![image](https://user-images.githubusercontent.com/111075855/216412205-c86b6987-5caa-4283-a8da-3a7e4328e12f.png)

