### PR TITLE
Link Coaching Dashboard

### DIFF
--- a/components/coding/profileV2/achievement_components/AchievementComponent.tsx
+++ b/components/coding/profileV2/achievement_components/AchievementComponent.tsx
@@ -36,7 +36,7 @@ const AchievementComponent = ({ userId }: AchievementComponentProps) => {
       setUnitBadges(data.intro_course_unit);
     },
   });
-  const {} = useQuery<FetchUserRoleData>(FETCH_USER_ROLE, {
+  useQuery<FetchUserRoleData>(FETCH_USER_ROLE, {
     variables: {
       _id: userId,
     },
@@ -100,7 +100,6 @@ const AchievementComponent = ({ userId }: AchievementComponentProps) => {
       <div className="flex justify-end w-full ">
         {isEditButtonVisible && (
           <div>
-
             <button
               onClick={() => setEditMode(!editMode)}
               className="w-5 h-5 cursor-pointer hover:text-yellow-600"
@@ -111,7 +110,6 @@ const AchievementComponent = ({ userId }: AchievementComponentProps) => {
                   (editMode ? "text-yellow-600" : "hover:text-yellow-600")
                 }
               />
-
             </button>
           </div>
         )}
@@ -153,7 +151,6 @@ const AchievementComponent = ({ userId }: AchievementComponentProps) => {
           </button>
         </div>
       )}
-
     </div>
   );
 };

--- a/components/coding/profileV2/achievement_components/AchievementComponent.tsx
+++ b/components/coding/profileV2/achievement_components/AchievementComponent.tsx
@@ -17,6 +17,7 @@ import {
   FetchUserRoleData,
   FETCH_USER_ROLE,
 } from "../../../../graphql/fetchUserRole";
+import { useAuth } from "../../../../lib/authContext";
 
 export type AchievementComponentProps = {
   userId: string;
@@ -28,6 +29,7 @@ const AchievementComponent = ({ userId }: AchievementComponentProps) => {
   const [editMode, setEditMode] = useState(false);
   // isEditButtonVisible set to true only when a coach clicks the PencilAltIcon Component
   const [isEditButtonVisible, setisEditButtonVisible] = useState(false);
+
   const { data } = useQuery<FetchBadgeResponse>(FETCH_CODING_BADGES, {
     variables: {
       userId: userId,
@@ -36,9 +38,11 @@ const AchievementComponent = ({ userId }: AchievementComponentProps) => {
       setUnitBadges(data.intro_course_unit);
     },
   });
+  const { user } = useAuth();
+
   useQuery<FetchUserRoleData>(FETCH_USER_ROLE, {
     variables: {
-      _id: userId,
+      _id: user.uid,
     },
     onCompleted: (roleData) => {
       if (roleData.users[0].userRole.value === "coach") {

--- a/pages/coaching-dashboard.tsx
+++ b/pages/coaching-dashboard.tsx
@@ -14,6 +14,7 @@ import {
   FetchTotalBadgesCountResponse,
   FETCH_TOTAL_USER_BADGES_COUNT,
 } from "../graphql/fetchTotalUserBadgesCount";
+
 const coachingDashboard = () => {
   const dispatch = useDispatch();
 
@@ -53,7 +54,7 @@ const coachingDashboard = () => {
         {userList.map((it, index) => {
           return (
             <div key={index}>
-              <Link href={"profile/" + it.link}>
+              <Link href={"profile/v2/" + it.id}>
                 <div className="">
                   <ProfileDetailCard
                     avatar={


### PR DESCRIPTION
This PR links each card in the coaching dashboard to ...profile/v2/[userId].
Key Notes:
- After linking to profile/v2/[userId], only [userId]'s that were coaches would have editable badges. So I updated AchievementComponent to check if the logged-in user is a coach (not the user whose card is being viewed as it was before)
- After editing and saving badge selections a refresh is required to see the new selections. Simply navigating away and back to the profile/v2/[userId] is not enough to trigger the UI badge update.
![image](https://user-images.githubusercontent.com/99484575/216621292-f35e75ef-547d-4a70-885d-91057401954f.png)
![image](https://user-images.githubusercontent.com/99484575/216621352-ab620b9c-b9da-4821-9b64-9cc286008e62.png)
