### PR TITLE
Update Bootcamp to Academy wherever applicable

### DIFF
--- a/components/SignInPage.tsx
+++ b/components/SignInPage.tsx
@@ -27,7 +27,7 @@ export default function SignInPage() {
       <div className="z-0 grid grid-cols-1 sm:grid-cols-2">
         <div className="w-full h-0 px-16 pt-16 -mt-16 sm:pt-64 sm:h-screen bg-signInBackground">
           <h2 className="text-2xl font-bold text-white">
-            Skillify is a coding bootcamp that specializes in mobile and web
+            Skillify is a coding academy that specializes in mobile and web
             development.
           </h2>
         </div>

--- a/components/coding/landing/WhatYouGet.tsx
+++ b/components/coding/landing/WhatYouGet.tsx
@@ -45,10 +45,10 @@ export default function WhatYouGet() {
         "Access to ALL of our digital training including web development, artifical intelligence, VR/AR, cyber security, game development, blockchain development, algorithms, interviewing & MORE!...",
     },
     {
-      title: "FREE Skillify Bootcamp Events",
+      title: "FREE Skillify Academy Events",
       value: "$5000+ Value",
       description:
-        "Get FREE access to our Skillify Bootcamp Events that cost $100 - $500 to attend! Including micro-trainings for UX/UI Design, Agile Methodology, Product Management and Digital Marketing",
+        "Get FREE access to our Skillify Academy Events that cost $100 - $500 to attend! Including micro-trainings for UX/UI Design, Agile Methodology, Product Management and Digital Marketing",
     },
     {
       title: "Quarterly Live Virtual 2-3 Day Hackathons",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -26,7 +26,7 @@ class MyDocument extends Document {
           <meta
             name="description"
             content={
-              "Toronto's best coding bootcamp for online learning! We teach high demand skills to help you get hired in the tech industry."
+              "Toronto's best coding academy for online learning! We teach high demand skills to help you get hired in the tech industry."
             }
           />
           <meta property="og:title" content={"Skillify"} />
@@ -37,7 +37,7 @@ class MyDocument extends Document {
           <meta
             property="og:description"
             content={
-              "Toronto's best coding bootcamp for online learning! We teach high demand skills to help you get hired in the tech industry."
+              "Toronto's best coding academy for online learning! We teach high demand skills to help you get hired in the tech industry."
             }
           />
           <meta property="og:url" content="https://skillify.ca/" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -75,7 +75,7 @@ const HomePage = () => {
       <SEO
         title={"Skillify"}
         description={
-          "Toronto's best coding bootcamp for online learning! We teach high demand skills to help you get hired in the tech industry."
+          "Toronto's best coding academy for online learning! We teach high demand skills to help you get hired in the tech industry."
         }
         image={"https://www.skillify.ca/images/logo.svg"}
       />

--- a/pages/waitlist-thank-you.tsx
+++ b/pages/waitlist-thank-you.tsx
@@ -5,9 +5,9 @@ export default function Page() {
   return (
     <div>
       <SEO
-        title={"Skillify Bootcamp Joined Waitlist"}
+        title={"Skillify Academy Joined Waitlist"}
         description={
-          "Thank you for joining the waitlist for the Skillify Bootcamp"
+          "Thank you for joining the waitlist for the Skillify Academy"
         }
         image={"https://melv1n.com/img/learn-to-code-how-to-start.png"}
       />

--- a/pages/whyisthisimportant.tsx
+++ b/pages/whyisthisimportant.tsx
@@ -21,8 +21,8 @@ export default function Page() {
             ones that don't
           </h1>
           <p className="pt-10 font-semibold text-center ">
-            The system I provide in The Skillify Bootcamp helps you learn to
-            code in a way that eliminates stress and will impress employers. By
+            The system I provide in The Skillify Academy helps you learn to code
+            in a way that eliminates stress and will impress employers. By
             simply working through our course content and meeting with our
             expert mentors, you instantly set yourself up for a career in tech.
           </p>
@@ -39,11 +39,8 @@ export default function Page() {
             <h1 className="p-16 text-4xl font-bold text-center text-gray-900  ">
               Traditional coding bootcamps don't deliver on their promises
             </h1>
-            <h2 className = "mx-16 border-t-2  border-solid border-black-500">
+            <h2 className="mx-16 border-t-2  border-solid border-black-500"></h2>
 
-            </h2>
-
-          
             <div className="pt-16 pb-16 pl-16">
               <p className="font-bold">
                 Because they realized that it was too easy to make a quick sale
@@ -76,23 +73,17 @@ export default function Page() {
               get a job at your dream company... it's also the fastest way to
               get hired at ANY company
             </h1>
-            <h2 className = "mx-16 border-t-2 border-solid border-black-500">
-
-            </h2>
+            <h2 className="mx-16 border-t-2 border-solid border-black-500"></h2>
 
             <h1 className="pt-20 pb-16 text-4xl font-bold text-center text-gray-900 ">
               What if you don't adapt ?
             </h1>
-            <h2 className = "mx-16 border-t-2  border-solid border-black-500">
-
-            </h2>
+            <h2 className="mx-16 border-t-2  border-solid border-black-500"></h2>
             <h1 className="pt-20 pb-16 text-4xl text-center text-gray-900 ">
               We are in the midst of The Great Resignation
             </h1>
-            <h2 className = "mx-16 border-t-2 border-solid border-black-500">
+            <h2 className="mx-16 border-t-2 border-solid border-black-500"></h2>
 
-            </h2>
-            
             <p className="pt-16 text-center">
               <b>
                 {" "}


### PR DESCRIPTION
In this PR I CTR+SHIFT+F searched for bootcamp and swapped all applicable and relevant displayed text to academy.

This includes the description included when you link to skillify.
![image](https://user-images.githubusercontent.com/99484575/219802934-0ba07bb8-0ca4-407e-a588-60d3d35d54c1.png)

and the landing page  
![image](https://user-images.githubusercontent.com/99484575/219802977-dd66f7b7-35e3-43bf-af75-4da90e80eb2b.png)
![image](https://user-images.githubusercontent.com/99484575/219803009-c86b86ba-11ab-4086-ba4c-8b949a81e368.png)
