### PR TITLE
Add a theme switcher to the top of the student portal

### DIFF
--- a/components/coding/PageHeader.tsx
+++ b/components/coding/PageHeader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function PageHeader({ title, description }) {
   return (
-    <div className="py-4 mb-8 bg-white dark:bg-gray-800 text-murkrow dark:text-white">
+    <div className="py-4 mb-8">
       <h1 className="text-3xl font-bold">{title}</h1>
 
       <p className="">{description}</p>

--- a/components/coding/SkillRatingsComponent.tsx
+++ b/components/coding/SkillRatingsComponent.tsx
@@ -57,21 +57,21 @@ export default function SkillRatingsComponent({
 
   const activeTabStyling = (tab: string) => {
     let styling =
-      "ml-8 justify-content-center text-2xl dark:text-white text-gray-500 w-36 py-2 h-12 cursor-pointer ";
+      "ml-8 justify-content-center text-2xl text-textPrimary w-36 py-2 h-12 cursor-pointer ";
     if (tab === activeTab) {
       styling =
         styling +
-        "text-black-500 underline dark:hover:text-orange-300 decoration-[0.18rem] underline-offset-[18px]";
+        "text-black-500 underline hover:text-brandPrimary decoration-[0.18rem] underline-offset-[18px]";
     } else {
       styling =
         styling +
-        "hover:text-black-500 dark:hover:text-orange-300 hover:underline hover:decoration-[0.18rem] hover:underline-offset-[18px] dark:hover:und";
+        "hover:text-black-500 hover:text-brandPrimary hover:underline hover:decoration-[0.18rem] hover:underline-offset-[18px]";
     }
     return styling;
   };
 
   return (
-    <div className="flex  py-8 flex-col w-full overflow-auto-bg-scroll">
+    <div className="flex flex-col w-full py-8 overflow-auto-bg-scroll">
       <div className="">
         {sections.map((it, i) => (
           <animated.button

--- a/components/coding/studentPortal/Layout.tsx
+++ b/components/coding/studentPortal/Layout.tsx
@@ -97,8 +97,8 @@ function Header({
   return (
     <div className="grid w-full h-16 grid-cols-3 border-b-2 bg-backgroundPrimary">
       {/* <div /> */}
-      <div onClick={handleMenuIconClick}>
-        <div className="cursor-pointer dark:text-white lg:hidden">
+      <div onClick={handleMenuIconClick} className="flex items-center pl-4">
+        <div className="cursor-pointer text-textPrimary lg:hidden">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="w-8 h-8"
@@ -120,7 +120,20 @@ function Header({
         onClick={handleToggleClick}
         className="flex items-center justify-end pr-4"
       >
-        <Button backgroundColor="primary" label="Theme" />
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="1.5"
+          stroke="currentColor"
+          className="w-6 h-6 text-textPrimary"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
+          />
+        </svg>
       </div>
     </div>
   );

--- a/components/coding/studentPortal/Layout.tsx
+++ b/components/coding/studentPortal/Layout.tsx
@@ -8,9 +8,17 @@ import {
 } from "../../../graphql/fetchUserGoalsCount";
 import { useAuth } from "../../../lib/authContext";
 import { setIsGoalApproaching } from "../../../redux/sidebarSlice";
+import { Button } from "../../ui/Button";
 import Sidebar from "./Sidebar";
 
+enum Theme {
+  DEFAULT = "theme-default",
+  DRACULA = "theme-dracula",
+}
+
 export const Layout: React.FC = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(Theme.DEFAULT);
+
   const [active, setActive] = useState(false);
 
   const { user } = useAuth();
@@ -33,7 +41,7 @@ export const Layout: React.FC = ({ children }) => {
   });
 
   return (
-    <div className="flex flex-col h-full bg-white">
+    <div className={`flex flex-col h-full bg-white ${theme}`}>
       <style global jsx>{`
         html,
         body,
@@ -45,7 +53,15 @@ export const Layout: React.FC = ({ children }) => {
       `}</style>
 
       <div className="fixed z-20 w-full">
-        <Header handleMenuIconClick={() => setActive(!active)} />
+        <Header
+          handleMenuIconClick={() => setActive(!active)}
+          handleToggleClick={() =>
+            setTheme((prev) =>
+              prev === Theme.DEFAULT ? Theme.DRACULA : Theme.DEFAULT
+            )
+          }
+          theme={theme}
+        />
       </div>
       <div className="flex">
         {/* Desktop Sidebar */}
@@ -53,7 +69,7 @@ export const Layout: React.FC = ({ children }) => {
           <Sidebar />
         </div>
         <div
-          className={` dark:text-white overflow-auto pt-16 w-full max-h-screen h-full transition-all transform duration-500 ease-in-out grid grid-cols-1 bg-white dark:bg-gray-800`}
+          className={`overflow-auto pt-16 w-full max-h-screen h-full transition-all transform duration-500 ease-in-out grid grid-cols-1 bg-backgroundPrimary text-textPrimary`}
         >
           <div className="min-h-screen">
             <div>{children}</div>
@@ -73,11 +89,14 @@ export const Layout: React.FC = ({ children }) => {
   );
 };
 
-function Header({ handleMenuIconClick }) {
-  const [darkToggle, setDarkToggle] = useState(false);
-
+function Header({
+  handleMenuIconClick,
+  handleToggleClick,
+  theme = Theme.DEFAULT,
+}) {
   return (
-    <div className="flex justify-between w-full h-16 p-4 border-b-2 bg-primary">
+    <div className="grid w-full h-16 grid-cols-3 border-b-2 bg-backgroundPrimary">
+      {/* <div /> */}
       <div onClick={handleMenuIconClick}>
         <div className="cursor-pointer dark:text-white lg:hidden">
           <svg
@@ -90,16 +109,18 @@ function Header({ handleMenuIconClick }) {
           </svg>
         </div>
       </div>
-      <img className="visible w-48 h-8 dark:hidden" src="/images/logo.svg" />
-      <img
-        className="hidden w-48 h-8 dark:visisble"
-        src="/images/logo-dark.svg"
-      />
-      <div>
-        <label className="toggleDarkBtn">
-          <input type="checkbox" onClick={() => setDarkToggle(!darkToggle)} />
-          <span className="slideBtnTg round"></span>
-        </label>
+      <div className="place-self-center">
+        {theme === Theme.DEFAULT ? (
+          <img className="w-48 h-8 " src="/images/logo.svg" />
+        ) : theme === Theme.DRACULA ? (
+          <img className="w-48 h-8" src="/images/logo-dark.svg" />
+        ) : null}
+      </div>
+      <div
+        onClick={handleToggleClick}
+        className="flex items-center justify-end pr-4"
+      >
+        <Button backgroundColor="primary" label="Theme" />
       </div>
     </div>
   );

--- a/components/coding/studentPortal/Layout.tsx
+++ b/components/coding/studentPortal/Layout.tsx
@@ -74,8 +74,10 @@ export const Layout: React.FC = ({ children }) => {
 };
 
 function Header({ handleMenuIconClick }) {
+  const [darkToggle, setDarkToggle] = useState(false);
+
   return (
-    <div className="flex justify-between w-full h-16 p-4 bg-white border-b-2 dark:bg-gray-900">
+    <div className="flex justify-between w-full h-16 p-4 border-b-2 bg-primary">
       <div onClick={handleMenuIconClick}>
         <div className="cursor-pointer dark:text-white lg:hidden">
           <svg
@@ -93,7 +95,12 @@ function Header({ handleMenuIconClick }) {
         className="hidden w-48 h-8 dark:visisble"
         src="/images/logo-dark.svg"
       />
-      <div />
+      <div>
+        <label className="toggleDarkBtn">
+          <input type="checkbox" onClick={() => setDarkToggle(!darkToggle)} />
+          <span className="slideBtnTg round"></span>
+        </label>
+      </div>
     </div>
   );
 }

--- a/components/coding/studentPortal/ResourceRow.tsx
+++ b/components/coding/studentPortal/ResourceRow.tsx
@@ -19,15 +19,15 @@ export const ResourceRow: React.FC<ResourceRowProps> = ({
   link,
 }: ResourceRowProps) => {
   return (
-    <div className="grid grid-cols-1 gap-4 p-6 bg-white shadow-lg dark:bg-gray-900 lg:grid-cols-resource-row">
-      <div className="flex items-center">
-        <img src={image} className="w-16 h-16 " />
+    <div className="grid grid-cols-1 gap-4 border-2 rounded shadow-lg bg-backgroundPrimary lg:grid-cols-resource-row border-textPrimary">
+      <div className="flex items-center justify-center bg-white rounded-l-sm border-l-textPrimary">
+        <img src={image} className="object-cover w-16" />
       </div>
-      <div className="flex flex-col">
-        <h2 className="font-bold dark:text-white">{title}</h2>
-        <p className="dark:text-white">{description}</p>
+      <div className="flex flex-col p-6 ">
+        <h2 className="font-bold">{title}</h2>
+        <p className="">{description}</p>
       </div>
-      <div className="flex items-center sm:justify-end">
+      <div className="flex items-center p-6 sm:justify-end">
         <a target="_blank" href={link} rel="noopener noreferrer">
           <Button label="View" disabled={disabled} />
         </a>

--- a/components/coding/studentPortal/ResourceRow.tsx
+++ b/components/coding/studentPortal/ResourceRow.tsx
@@ -20,7 +20,7 @@ export const ResourceRow: React.FC<ResourceRowProps> = ({
 }: ResourceRowProps) => {
   return (
     <div className="grid grid-cols-1 gap-4 border-2 rounded shadow-lg bg-backgroundPrimary lg:grid-cols-resource-row border-textPrimary">
-      <div className="flex items-center justify-center bg-white rounded-l-sm border-l-textPrimary">
+      <div className="flex items-center justify-center p-4 bg-white rounded-l-sm sm:p-0 border-l-textPrimary">
         <img src={image} className="object-cover w-16" />
       </div>
       <div className="flex flex-col p-6 ">

--- a/components/coding/studentPortal/Sidebar.tsx
+++ b/components/coding/studentPortal/Sidebar.tsx
@@ -35,9 +35,11 @@ const SidebarItem = ({
   return (
     <Link href={link}>
       <div
-        className={`flex flex-wrap items-center p-4 cursor-pointer hover:border-l-4 ${
-          activePage === page ? "border-charmander text-charmander" : ""
-        } hover:border-charmander hover:text-charmander`}
+        className={`flex flex-wrap items-center p-4 hover:border-l-4 ${
+          activePage === page
+            ? "border-l-4 border-brandPrimary text-brandPrimary cursor-default"
+            : "cursor-pointer hover:bg-backgroundSecondary"
+        } hover:border-brandPrimary hover:text-brandPrimary `}
       >
         <div>
           {notifications ? (
@@ -92,7 +94,7 @@ export const Sidebar: React.FC = () => {
 
   return (
     //Full width then restrict in page
-    <div className="flex flex-col w-full bg-white dark:bg-gray-900 dark:text-white">
+    <div className="flex flex-col w-full bg-backgroundPrimary text-textPrimary">
       <div className="grid">
         <div className="flex p-4">
           {user && (
@@ -217,7 +219,7 @@ export const Sidebar: React.FC = () => {
           </div>
           <div className="overflow-auto h-36">
             <Link href="/studentPortal">
-              <div className="flex p-4 bg-white shadow-sm cursor-pointer dark:bg-gray-900 hover:text-charmander hover:bg-yellow-50 dark:hover:bg-gray-800">
+              <div className="flex p-4 shadow-sm cursor-pointer bg-backgroundPrimary hover:text-charmander hover:bg-backgroundHover">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   className="w-6 h-6"
@@ -236,7 +238,7 @@ export const Sidebar: React.FC = () => {
               </div>
             </Link>
             <Link href="/studentPortal/web">
-              <div className="flex p-4 bg-white cursor-pointer dark:bg-gray-900 hover:text-charmander hover:bg-yellow-50 dark:hover:bg-gray-800">
+              <div className="flex p-4 cursor-pointer bg-backgroundPrimary hover:text-charmander hover:bg-backgroundHover">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   className="w-6 h-6"

--- a/components/coding/studentPortal/UnitNodeView.tsx
+++ b/components/coding/studentPortal/UnitNodeView.tsx
@@ -47,10 +47,10 @@ export const UnitNodeView: React.FC<UnitNodeViewProps> = ({
         className={`${
           locked
             ? ""
-            : "hover:bg-white dark:hover:bg-gray-700 hover:shadow-lg hover:py-4 transform transition-all"
+            : "hover:bg-backgroundSecondary hover:shadow-lg hover:py-4 transform transition-all"
         } ${
           active
-            ? "px-4 sm:px-0 py-4 border-2 flex flex-col sm:grid sm:grid-cols-12 bg-white dark:bg-gray-800"
+            ? "px-4 sm:px-0 py-4 border-2 flex flex-col sm:grid sm:grid-cols-12 bg-backgroundPrimary"
             : "grid grid-cols-12"
         }  `}
       >

--- a/components/coding/studentPortal/quiz/MCOption.tsx
+++ b/components/coding/studentPortal/quiz/MCOption.tsx
@@ -39,11 +39,11 @@ export default function MCOption({ text, state }: MCOptionProps) {
 
   return (
     <div
-      className={`flex items-center h-16 px-6 bg-white dark:bg-gray-900 rounded-md w-full ${getBorderColour(
+      className={`flex items-center h-16 px-6 bg-backgroundSecondary rounded-md w-full ${getBorderColour(
         state
       )}`}
     >
-      <div className="flex items-center justify-center w-6 h-6 mr-6 bg-gray-200 dark:bg-gray-400 rounded-full">
+      <div className="flex items-center justify-center w-6 h-6 mr-6 bg-gray-200 rounded-full dark:bg-gray-400">
         <div
           className={`w-4 h-4 rounded-full ${getRadioButtonColour(state)}`}
         ></div>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -5,6 +5,7 @@ export interface ButtonProps {
    * What background color to use
    */
   backgroundColor?:
+    | "primary"
     | "blue"
     | "green"
     | "red"
@@ -45,7 +46,7 @@ export const Button: React.FC<ButtonProps> = ({
   let backgroundStyles;
   switch (backgroundColor) {
     case "primary":
-      backgroundStyles = "bg-charmander hover:bg-pikachu-500";
+      backgroundStyles = "bg-brandPrimary hover:bg-pikachu-500";
       break;
     case "blue":
       backgroundStyles = "bg-blue-500 border-blue-900 hover:bg-blue-400";

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -84,7 +84,7 @@ class MyDocument extends Document {
             src="https://www.googletagmanager.com/gtag/js?id=UA-235433930-1"
           ></script>
         </Head>
-        <body className="theme-default" style={this.bodyStyle}>
+        <body style={this.bodyStyle}>
           <Main />
           <NextScript />
           {/* <!-- Google Tag Manager (noscript) --> */}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -84,7 +84,7 @@ class MyDocument extends Document {
             src="https://www.googletagmanager.com/gtag/js?id=UA-235433930-1"
           ></script>
         </Head>
-        <body style={this.bodyStyle}>
+        <body className="theme-default" style={this.bodyStyle}>
           <Main />
           <NextScript />
           {/* <!-- Google Tag Manager (noscript) --> */}

--- a/pages/goals/index.tsx
+++ b/pages/goals/index.tsx
@@ -72,7 +72,7 @@ export default function Goals(props) {
         </div>
         {goalsSections.map((section) => {
           return (
-            <div className="mb-8">
+            <div className="mb-8" key={section.sectionName}>
               <GoalsSectionComponent
                 userGoals={section.userGoals}
                 sectionName={section.sectionName}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,4 +15,18 @@
   src: url("/fonts/Poppins/Poppins-Bold.ttf");
 }
 
+.theme-default {
+  --color-text-primary: rgb(238, 231, 9);
+  --color-text-secondary: rgb(238, 231, 9);
+  --color-background-primary: rgb(255, 106, 0);
+  --color-background-secondary: rgb(32, 129, 255);
+}
+
+.theme-dark {
+  --color-text-primary: rgb(43, 217, 136);
+  --color-text-secondary: rgb(238, 231, 9);
+  --color-background-primary: rgb(255, 11, 178);
+  --color-background-secondary: rgb(32, 129, 255);
+}
+
 @tailwind utilities;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,17 +16,19 @@
 }
 
 .theme-default {
-  --color-text-primary: rgb(238, 231, 9);
-  --color-text-secondary: rgb(238, 231, 9);
-  --color-background-primary: rgb(255, 106, 0);
-  --color-background-secondary: rgb(32, 129, 255);
+  --color-text-primary: rgb(0, 0, 0);
+  --color-background-primary: rgb(255, 255, 255);
+  --color-background-hover: rgb(254 252 232);
+  --color-background-secondary: rgb(255 255 255);
+  --color-brand-primary: rgb(241, 135, 1);
 }
 
-.theme-dark {
-  --color-text-primary: rgb(43, 217, 136);
-  --color-text-secondary: rgb(238, 231, 9);
-  --color-background-primary: rgb(255, 11, 178);
-  --color-background-secondary: rgb(32, 129, 255);
+.theme-dracula {
+  --color-text-primary: rgb(255, 255, 255);
+  --color-background-primary: rgb(17 24 39);
+  --color-background-hover: rgb(30 41 59);
+  --color-background-secondary: rgb(30 41 59);
+  --color-brand-primary: rgb(241, 135, 1);
 }
 
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
-const { backgroundColor } = require("tailwindcss/defaultTheme");
 const defaultTheme = require("tailwindcss/defaultTheme");
+const colors = require("tailwindcss/colors");
 
 module.exports = {
   mode: "jit",
@@ -8,6 +8,16 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
+    textColor: {
+      primary: "var(--color-text-primary)",
+      secondary: "var(--color-text-secondary)",
+      ...colors,
+    },
+    backgroundColor: {
+      primary: "var(--color-background-primary)",
+      secondary: "var(--color-background-secondary)",
+      ...colors,
+    },
     extend: {
       width: {
         108: "27rem",
@@ -99,28 +109,28 @@ module.exports = {
           "100%": { opacity: "1", transform: "scale(1)" },
         },
         slideDownAndFade: {
-          from: { opacity: 0, transform: 'translateY(-2px)' },
-          to: { opacity: 1, transform: 'translateY(0)' },
+          from: { opacity: 0, transform: "translateY(-2px)" },
+          to: { opacity: 1, transform: "translateY(0)" },
         },
         slideLeftAndFade: {
-          from: { opacity: 0, transform: 'translateX(2px)' },
-          to: { opacity: 1, transform: 'translateX(0)' },
+          from: { opacity: 0, transform: "translateX(2px)" },
+          to: { opacity: 1, transform: "translateX(0)" },
         },
         slideUpAndFade: {
-          from: { opacity: 0, transform: 'translateY(2px)' },
-          to: { opacity: 1, transform: 'translateY(0)' },
+          from: { opacity: 0, transform: "translateY(2px)" },
+          to: { opacity: 1, transform: "translateY(0)" },
         },
         slideRightAndFade: {
-          from: { opacity: 0, transform: 'translateX(2px)' },
-          to: { opacity: 1, transform: 'translateX(0)' },
+          from: { opacity: 0, transform: "translateX(2px)" },
+          to: { opacity: 1, transform: "translateX(0)" },
         },
         overlayShow: {
           from: { opacity: 0 },
           to: { opacity: 1 },
         },
         contentShow: {
-          from: { opacity: 0, transform: 'translate(-50%, -48%) scale(0.96)' },
-          to: { opacity: 1, transform: 'translate(-50%, -50%) scale(1)' },
+          from: { opacity: 0, transform: "translate(-50%, -48%) scale(0.96)" },
+          to: { opacity: 1, transform: "translate(-50%, -50%) scale(1)" },
         },
       },
       outline: {
@@ -130,15 +140,16 @@ module.exports = {
       secondary: "#ff8e4f",
     },
     animation: {
-      slideDownAndFade: 'slideDownAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)',
-      slideLeftAndFade: 'slideLeftAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)',
-      slideUpAndFade: 'slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)',
-      slideRightAndFade: 'slideRightAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)',
-      overlayShow: 'overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
-        contentShow: 'contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)',
+      slideDownAndFade: "slideDownAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+      slideLeftAndFade: "slideLeftAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+      slideUpAndFade: "slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+      slideRightAndFade:
+        "slideRightAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)",
+      overlayShow: "overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)",
+      contentShow: "contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1)",
     },
   },
-  
+
   options: {
     /**
      * PurgeCSS:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,16 +8,6 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    textColor: {
-      primary: "var(--color-text-primary)",
-      secondary: "var(--color-text-secondary)",
-      ...colors,
-    },
-    backgroundColor: {
-      primary: "var(--color-background-primary)",
-      secondary: "var(--color-background-secondary)",
-      ...colors,
-    },
     extend: {
       width: {
         108: "27rem",
@@ -33,6 +23,10 @@ module.exports = {
         fadeIn_half: "fadeInHalf 1s ease-in-out",
       },
       colors: {
+        textPrimary: "var(--color-text-primary)",
+        brandPrimary: "var(--color-brand-primary)",
+        backgroundPrimary: "var(--color-background-primary)",
+        backgroundSecondary: "var(--color-background-secondary)",
         charmander: "#F18701",
         rattata: "#7678ED",
         pikachu: {
@@ -153,6 +147,13 @@ module.exports = {
   options: {
     /**
      * PurgeCSS:
+     * bg-backgroundSecondary
+     * bg-backgroundPrimary
+     * bg-textPrimary
+     * bg-textSecondary
+     * text-textPrimary
+     * text-textSecondary
+     * hover:text-textSecondary
      * bg-blue-300
      * bg-yellow-300
      * bg-green-300
@@ -227,6 +228,7 @@ module.exports = {
       "bg-yellow-700",
       "border-yellow-900",
       "hover:bg-yellow-400",
+      "hover:text-textSecondary",
       "text-yellow-100",
       "text-yellow-200",
       "text-yellow-400",


### PR DESCRIPTION
This PR is a large refactor. Instead of using tailwind dark: prefixes, we're going to support a default and a dark theme. This will allow the user to toggle between the two themes. It will also allow for new themes to be supported in the future.

Several components required refactoring to use the new tailwind themed colors.