### PR TITLE
ProgressFreemiumComponent and storybook

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,1 @@
-{
-"editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true
-    }
-}
+{}

--- a/components/ui/ProgressFreemiumComponent.stories.tsx
+++ b/components/ui/ProgressFreemiumComponent.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, Story } from "@storybook/react";
+import ProgressFreemiumComponent, {
+  ProgressFreemiumComponentProps,
+} from "./ProgressFreemiumComponent";
+import React from "react";
+
+export default {
+  title: "UI/Progress",
+  component: ProgressFreemiumComponent,
+} as Meta;
+
+const Template: Story<ProgressFreemiumComponentProps> = (args) => (
+  <ProgressFreemiumComponent {...args}></ProgressFreemiumComponent>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  elapsedDays: 15,
+  totalTrialDays: 30,
+};

--- a/components/ui/ProgressFreemiumComponent.tsx
+++ b/components/ui/ProgressFreemiumComponent.tsx
@@ -1,0 +1,39 @@
+import { Indicator, Root } from "@radix-ui/react-progress";
+import React, { useEffect, useState } from "react";
+
+export interface ProgressFreemiumComponentProps {
+  elapsedDays: number;
+  totalTrialDays: number;
+}
+const ProgressBarComponent: React.FC<ProgressFreemiumComponentProps> = ({
+  elapsedDays,
+  totalTrialDays,
+}) => {
+  const [progress, setProgress] = useState(0);
+  useEffect(() => {
+    setProgress(elapsedDays);
+  }, []);
+
+  return (
+    <div>
+      <Root
+        className="relative overflow-hidden bg-white rounded-full w-4/5 h-[8px]"
+        style={{
+          transform: "translateZ(0)",
+        }}
+        value={progress}
+      >
+        <Indicator
+          className="bg-rattata w-full h-full transition-transform duration-[660ms] ease-[cubic-bezier(0.65, 0, 0.35, 1)]"
+          style={{
+            transform: `translateX(-${
+              100 - (progress / totalTrialDays) * 100
+            }%)`,
+          }}
+        />
+      </Root>
+    </div>
+  );
+};
+
+export default ProgressBarComponent;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@hotjar/browser": "^1.0.6",
     "@magic-ext/oauth": "^2.1.1",
     "@matejmazur/react-katex": "^3.1.3",
+    "@radix-ui/react-progress": "^1.0.1",
     "@radix-ui/react-tooltip": "^1.0.3",
     "@react-spring/web": "^9.6.1",
     "@react-three/drei": "^7.27.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "next lint",
     "start": "next start",
     "test": "env TZ='UTC' jest",
-    "storybook": "start-storybook -s ./public -p 6006",
+    "storybook": "export NODE_OPTIONS=--openssl-legacy-provider && start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook -s public",
     "chromatic": "npx chromatic --project-token=3849dc6eb670"
   },


### PR DESCRIPTION
In this PR I did the following: 
1. Added ProgressFreemiumComponent
2. created assocaited storybook
3. added a line to the storybook script file 
https://github.com/webpack/webpack/issues/14532

THIS WAS THE ERROR:
web/node_modules/loader-runner/lib/LoaderRunner.js:205:4 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

![image](https://user-images.githubusercontent.com/111075855/221387012-cf4def75-6981-4b12-bebb-4e257050735c.png)

This component will be used in the Sidebar to display #daysCompletedInTrial/TotalTrialDays under the user's avatar.