### PR TITLE
Freemium Header

### DIFF
--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { elapsedDays } from "../../../pages/api/studentPortal/freemium/elapsedDays";
+import { trialDaysRemaining } from "../../../pages/api/studentPortal/freemium/trialDaysRemaining";
+import { Theme } from "../../../redux/themeSlice";
+import { Button } from "../../ui/Button";
+import ProgressComponent from "../../ui/ProgressComponent";
+
+export type FreemiumHeader = {
+  handleMenuIconClick: () => void;
+  handleToggleClick: () => void;
+  theme: Theme;
+  createdAt: Date;
+};
+export const FreemiumHeader = ({
+  handleMenuIconClick,
+  handleToggleClick,
+  theme = Theme.DEFAULT,
+  createdAt,
+}) => {
+  const TOTAL_TRIAL_DAYS = 30;
+
+  return (
+    <div className="grid w-full h-16 grid-cols-4 border-b-2 bg-backgroundPrimary">
+      <div className="col-span-1 flex items-center pl-4">
+        {theme === Theme.DEFAULT ? (
+          <img className="w-48 h-8 " src="/images/logo.svg" />
+        ) : theme === Theme.DRACULA ? (
+          <img className="w-48 h-8" src="/images/logo-dark.svg" />
+        ) : null}
+      </div>
+      <div className="col-span-2 flex items-center justify-end space-x-6 pr-4">
+        <div className="hidden lg:block">
+          <p className="font-bold">Enjoying the Skillify Experience?</p>
+          <ProgressComponent
+            currentValue={elapsedDays(createdAt, TOTAL_TRIAL_DAYS)}
+            totalValue={TOTAL_TRIAL_DAYS}
+          />
+          <p className="text-xs mt-1 text-gray-500">
+            {trialDaysRemaining(createdAt, TOTAL_TRIAL_DAYS)}/{TOTAL_TRIAL_DAYS}{" "}
+            days remaining
+          </p>
+        </div>
+        <Button label="Apply Now!" />
+      </div>
+      <div
+        onClick={handleToggleClick}
+        className="flex items-center justify-end pr-4"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="1.5"
+          stroke="currentColor"
+          className="w-6 h-6 text-textPrimary"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
+          />
+        </svg>
+      </div>
+    </div>
+  );
+};

--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -5,18 +5,17 @@ import { Theme } from "../../../redux/themeSlice";
 import { Button } from "../../ui/Button";
 import ProgressComponent from "../../ui/ProgressComponent";
 
-export type FreemiumHeader = {
+export type FreemiumHeaderProps = {
   handleMenuIconClick: () => void;
   handleToggleClick: () => void;
   theme: Theme;
   createdAt: Date;
 };
 export const FreemiumHeader = ({
-  handleMenuIconClick,
   handleToggleClick,
   theme = Theme.DEFAULT,
   createdAt,
-}) => {
+}: FreemiumHeaderProps) => {
   const TOTAL_TRIAL_DAYS = 30;
 
   return (

--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -20,15 +20,15 @@ export const FreemiumHeader = ({
   const TOTAL_TRIAL_DAYS = 30;
 
   return (
-    <div className="grid w-full h-16 grid-cols-4 border-b-2 bg-backgroundPrimary">
-      <div className="col-span-1 flex items-center pl-4">
+    <div className="grid w-full h-16 grid-cols-6 border-b-2 bg-backgroundPrimary">
+      <div className="col-span-2 flex items-center pl-4">
         {theme === Theme.DEFAULT ? (
           <img className="w-48 h-8 " src="/images/logo.svg" />
         ) : theme === Theme.DRACULA ? (
           <img className="w-48 h-8" src="/images/logo-dark.svg" />
         ) : null}
       </div>
-      <div className="col-span-2 flex items-center justify-end space-x-6 pr-4">
+      <div className="col-span-3 flex items-center justify-end space-x-6 pr-2">
         <div className="hidden lg:block">
           <p className="font-bold">Enjoying the Skillify Experience?</p>
           <ProgressComponent

--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -40,7 +40,14 @@ export const FreemiumHeader = ({
             days remaining
           </p>
         </div>
-        <Button label="Apply Now!" />
+        <a href="https://www.joinskillify.com/call">
+          <Button
+            label="Apply Now!"
+            onClick={(e) =>
+              window.scrollTo({ top: 0, left: 0, behavior: "smooth" })
+            }
+          />
+        </a>
       </div>
       <div
         onClick={handleToggleClick}

--- a/components/studentPortal/layout/Layout.tsx
+++ b/components/studentPortal/layout/Layout.tsx
@@ -7,15 +7,16 @@ import {
   FETCH_USER_GOALS_COUNT,
 } from "../../../graphql/studentPortal/goals/fetchUserGoalsCount";
 import { useAuth } from "../../../lib/authContext";
+import { profileSelector } from "../../../redux/profileSlice";
 import { setIsGoalApproaching } from "../../../redux/sidebarSlice";
 import { setTheme, Theme, themeSelector } from "../../../redux/themeSlice";
-import { Button } from "../../ui/Button";
+import { FreemiumHeader } from "../freemium/FreemiumHeader";
 import Sidebar from "./Sidebar";
 
 export const Layout: React.FC = ({ children }) => {
   const [active, setActive] = useState(false);
   const { currentTheme } = useSelector(themeSelector);
-
+  const { userRole, createdAt } = useSelector(profileSelector);
   const { user } = useAuth();
   const dispatch = useDispatch();
 
@@ -48,17 +49,31 @@ export const Layout: React.FC = ({ children }) => {
       `}</style>
 
       <div className="fixed z-20 w-full">
-        <Header
-          handleMenuIconClick={() => setActive(!active)}
-          handleToggleClick={() =>
-            dispatch(
-              currentTheme === Theme.DEFAULT
-                ? setTheme(Theme.DRACULA)
-                : setTheme(Theme.DEFAULT)
-            )
-          }
-          theme={currentTheme}
-        />
+        {userRole === "freemium" ? (
+          <FreemiumHeader
+            handleMenuIconClick={() => setActive(!active)}
+            handleToggleClick={() =>
+              dispatch(
+                currentTheme === Theme.DEFAULT
+                  ? setTheme(Theme.DRACULA)
+                  : setTheme(Theme.DEFAULT)
+              )
+            }
+            createdAt={createdAt}
+          />
+        ) : (
+          <Header
+            handleMenuIconClick={() => setActive(!active)}
+            handleToggleClick={() =>
+              dispatch(
+                currentTheme === Theme.DEFAULT
+                  ? setTheme(Theme.DRACULA)
+                  : setTheme(Theme.DEFAULT)
+              )
+            }
+            theme={currentTheme}
+          />
+        )}
       </div>
       <div className="flex">
         {/* Desktop Sidebar */}


### PR DESCRIPTION
Regular View:
![image](https://user-images.githubusercontent.com/111075855/224862490-bd361149-83f3-4c18-af3f-ef89ed98c3c7.png)
Mobile: 
![image](https://user-images.githubusercontent.com/111075855/224862550-4bf43f32-dae8-4d07-aa80-1cd4e8ed8c36.png)
Figma Sketch:
![image](https://user-images.githubusercontent.com/111075855/224864119-cdd0e108-066e-4c39-99d4-66d331494ccc.png)

Purpose: 
To create a customized header for the Freemium Component that includes a call to action to sign up that appears on the layout (every page).

1. Created a FreemiumHeader.tsx component that 
2. Check for the userRole/createdAt on the layout page and conditionally render the header components based on the userRole.

UI notes:
1. lined up the buttons for the apply now and the continue for the lessons...this was not the case in the sketches, but it seemed to look the best to me.  Thoughts? 
2. For the mobile view I removed the progress bar, etc. and left only the call to action -- button saying apply now!  I like this but am open to suggestions!
3. Kept the toggle button on the far right to toggle the themes.

Advice Needed: 
1. How do I get the "Enjoying the Skillify Experience" to show up white or grey when the theme is switched to dark?  I've noticed in dark mode a lot of the sidebar, etc. is not correct.  I did use dark: bg-white, but that doesn't work, as I'm sure I'm not fully understanding the interaction between tailwind and the dracula theme.  
