### PR TITLE
GraphQL mutation for FirstProLang (WIP)

### DIFF
--- a/graphql/quizzes/insertFirstProLang.tsx
+++ b/graphql/quizzes/insertFirstProLang.tsx
@@ -1,0 +1,13 @@
+import { gql } from "@apollo/client";
+
+export const INSERT_CODING_QUIZ_RESPONSE = gql`
+  mutation INSERT_CODING_QUIZ_RESPONSE($objects: [coding_quiz_insert_input!]!) {
+    insert_coding_quiz(objects: $objects) {
+      returning {
+        name
+        result
+        email
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This pull request adds the INSERT_CODING_QUIZ_RESPONSE mutation to the existing GraphQL schema. 

Here are the technical details:
- Utilizes Apollo Client's gql function to define the mutation
- Accepts an array of coding_quiz_insert_input objects as input
- Inserts the input objects into the 'coding_quiz' table
- Returns an array of inserted objects with the 'name', 'result', and 'email' fields

These changes will enable the client to insert coding quiz responses into the database with ease and retrieve the necessary data for analysis.