### PR TITLE
de-select to optionHandleClick function

### DIFF
--- a/graphql/quizzes/insertFirstProLang.ts
+++ b/graphql/quizzes/insertFirstProLang.ts
@@ -1,0 +1,13 @@
+import { gql } from "@apollo/client";
+
+export const INSERT_CODING_QUIZ_RESPONSE = gql`
+  mutation INSERT_CODING_QUIZ_RESPONSE($objects: [coding_quiz_insert_input!]!) {
+    insert_coding_quiz(objects: $objects) {
+      returning {
+        name
+        result
+        email
+      }
+    }
+  }
+`;

--- a/pages/resources/quizzes/FirstLang/FirstProgrammingLanguageQuiz.tsx
+++ b/pages/resources/quizzes/FirstLang/FirstProgrammingLanguageQuiz.tsx
@@ -63,7 +63,10 @@ const FirstProgrammingLanguageQuiz = () => {
       ...question,
       options: question.options.map((questionOption) =>
         questionOption.name === option.name
-          ? { ...questionOption, isSelected: true }
+          ? {
+              ...questionOption,
+              isSelected: questionOption.isSelected ? false : true,
+            }
           : questionOption
       ),
     }));
@@ -72,7 +75,6 @@ const FirstProgrammingLanguageQuiz = () => {
       ...quizViewState,
       questions: selectedQuizOption,
     };
-
     setQuizViewState(updatedQuizViewState);
   };
 


### PR DESCRIPTION
In this PR,

I further modified the handleOptionClick functionality to include de-selection. 

Also,

This PR adds the INSERT_CODING_QUIZ_RESPONSE mutation to the existing GraphQL schema.

Here are the technical details:

Utilizes Apollo Client's gql function to define the mutation
Accepts an array of coding_quiz_insert_input objects as input
Inserts the input objects into the 'coding_quiz' table
Returns an array of inserted objects with the 'name', 'result', and 'email' fields
These changes will enable the client to insert coding quiz responses into the database with ease and retrieve the necessary data for analysis.

Tested the mutation in the Hasura playground to ensure it worked as expected!