### PR TITLE
Add Fade Transition between the modals of the Onboarding Modal

### DIFF
--- a/components/studentPortal/freemium/FreemiumDialogueComponent.tsx
+++ b/components/studentPortal/freemium/FreemiumDialogueComponent.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { getModalContent } from "../../../pages/api/studentPortal/freemium/getModalContent";
 import { themeSelector } from "../../../redux/themeSlice";
+import FadeAnimation from "../../ui/animations/FadeAnimation";
 
 export enum ModalStage {
   ONE,
@@ -28,6 +29,7 @@ const FreemiumDialogComponent: React.FC = () => {
     <Root defaultOpen={true}>
       <Portal>
         <Overlay className="bg-opacity-90 bg-gray-500 data-[state=open]:animate-overlayShow fixed inset-0" />
+
         <Content className={`${currentTheme}`}>
           <div
             className={`fixed h-[450px] w-[300px] md:h-[600px] md:w-[900px] p-4 md:p-20 transform -translate-x-1/2 -translate-y-1/2 ${
@@ -35,7 +37,9 @@ const FreemiumDialogComponent: React.FC = () => {
             } rounded-lg left-1/2 top-1/2`}
           >
             {/* content rendered based on enum */}
-            {getModalContent(activeModal)}
+            <FadeAnimation key={activeModal} triggerAnimation={true}>
+              {getModalContent(activeModal)}
+            </FadeAnimation>
             <div className="flex flex-row justify-center items-center space-x-12 absolute bottom-0 bg-white p-4 inset-x-0">
               {/* no button/back button */}
               {activeModal > ModalStage.ONE ? (

--- a/components/ui/animations/FadeAnimation.tsx
+++ b/components/ui/animations/FadeAnimation.tsx
@@ -1,0 +1,27 @@
+import { animated, useTrail } from "@react-spring/web";
+import React from "react";
+
+export const FadeAnimation: React.FC<{
+  triggerAnimation: boolean;
+  children: React.ReactNode;
+}> = ({ triggerAnimation, children }) => {
+  const items = React.Children.toArray(children);
+  const trail = useTrail(items.length, {
+    config: { mass: 5, tension: 2000, friction: 200, duration: 400 },
+    opacity: triggerAnimation ? 1 : 0,
+    x: triggerAnimation ? 0 : 20,
+    height: triggerAnimation ? "auto" : 0,
+    from: { opacity: 0, y: 20, height: 0 },
+  });
+  return (
+    <div>
+      {trail.map(({ height, ...style }, index) => (
+        <animated.div key={index} style={style}>
+          <animated.div style={{ height }}>{items[index]}</animated.div>
+        </animated.div>
+      ))}
+    </div>
+  );
+};
+
+export default FadeAnimation;


### PR DESCRIPTION
Purpose of the PR: 
Add the transition between the components in the onboarding modal.

1.  I modified the useTrail animation component I found online to include a fade transition and put it into the UI Animation folder.
2.  I wrapped the this component around the getModalContent function which switches between the modals and then used the activeModal variable as the key to trigger each transition.