### PR TITLE
added sidebar menu icon to freemium user view

### DIFF
--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   calculateRemainingTrialDays,
   elapsedDays,
@@ -15,11 +16,24 @@ export type FreemiumHeaderProps = {
 };
 export const FreemiumHeader = ({
   handleToggleClick,
+  handleMenuIconClick,
   theme = Theme.DEFAULT,
   createdAt,
 }: FreemiumHeaderProps) => {
   return (
     <div className="grid w-full h-16 grid-cols-6 border-b-2 bg-backgroundPrimary">
+      <div onClick={handleMenuIconClick} className="flex items-center pl-4">
+        <div className="cursor-pointer text-textPrimary lg:hidden">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="w-8 h-8"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" />
+          </svg>
+        </div>
+      </div>
       <div className="col-span-2 flex items-center pl-4">
         {theme === Theme.DEFAULT ? (
           <img className="w-48 h-8 " src="/images/logo.svg" />

--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -21,7 +21,7 @@ export const FreemiumHeader = ({
   createdAt,
 }: FreemiumHeaderProps) => {
   return (
-    <div className="grid w-full h-16 grid-cols-6 border-b-2 bg-backgroundPrimary">
+    <div className="grid w-full h-16 grid-cols-7 border-b-2 bg-backgroundPrimary">
       <div onClick={handleMenuIconClick} className="flex items-center pl-4">
         <div className="cursor-pointer text-textPrimary lg:hidden">
           <svg

--- a/components/studentPortal/freemium/FreemiumHeader.tsx
+++ b/components/studentPortal/freemium/FreemiumHeader.tsx
@@ -22,7 +22,10 @@ export const FreemiumHeader = ({
 }: FreemiumHeaderProps) => {
   return (
     <div className="grid w-full h-16 grid-cols-7 border-b-2 bg-backgroundPrimary">
-      <div onClick={handleMenuIconClick} className="flex items-center pl-4">
+      <div
+        onClick={handleMenuIconClick}
+        className="flex md:hidden items-center pl-4"
+      >
         <div className="cursor-pointer text-textPrimary lg:hidden">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -34,7 +37,7 @@ export const FreemiumHeader = ({
           </svg>
         </div>
       </div>
-      <div className="col-span-2 flex items-center pl-4">
+      <div className="md:col-span-3 col-span-2 flex items-center pl-4">
         {theme === Theme.DEFAULT ? (
           <img className="w-48 h-8 " src="/images/logo.svg" />
         ) : theme === Theme.DRACULA ? (


### PR DESCRIPTION
Purpose of PR: 
To re-add the menu hamburger icon back to the freemium user view.  It was inadvertently left out when I created the FreemiumSidebarHeader.tsx.

This affected mobile views.

Mobile View:
![image](https://user-images.githubusercontent.com/111075855/234009351-9c187a45-6857-45df-bff4-b9d483ede118.png)
![image](https://user-images.githubusercontent.com/111075855/234009494-0e468295-aa6c-4b89-8233-5e9d1b423b4b.png)


