### PR TITLE
add sign up flow to plans page

### DIFF
--- a/components/studentPortal/freemium/PlansCard.tsx
+++ b/components/studentPortal/freemium/PlansCard.tsx
@@ -1,34 +1,38 @@
-import React from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "../../../lib/authContext";
+import { PlanCard } from "../../../pages/plans";
 import { Button } from "../../ui/Button";
-import PlanRow, { PlanRowProps } from "./PlanRow";
+import PlanRow from "./PlanRow";
 
 export type PlansCardProps = {
-  title: string;
-  price: string;
-  description: string;
-  buttonLabel: string;
-  onClick: () => void;
-  planRowData: PlanRowProps[];
+  planCard: PlanCard;
 };
 
-const PlansCard = ({
-  price,
-  description,
-  buttonLabel,
-  title,
-  onClick,
-  planRowData,
-}: PlansCardProps) => {
+const PlansCard = ({ planCard }: PlansCardProps) => {
+  const { planName, title, price, description, planCardRow, buttonLabel } =
+    planCard;
+
+  const { signIn } = useAuth();
+  const router = useRouter();
+
+  const handleSignUp = (planName: string) => {
+    if (planName === "premium") {
+      router.push("https://www.joinskillify.com/call");
+    } else {
+      signIn();
+    }
+  };
+
   return (
-    <div className="flex flex-col w-[325px] md:w-[400px] space-y-4 transition-all transform border-t-2 text-textPrimary bg-backgroundPrimary shadow-lg cursor-pointer rounded-xl hover:scale-105 mb-4">
-      <div className="flex items-center justify-center bg-rattata p-6 text-white font-bold text-2xl rounded-xl">
+    <div className="flex flex-col w-[325px] md:w-[400px] space-y-4 shadow-lg cursor-pointer rounded-xl hover:scale-105">
+      <div className="flex justify-center bg-rattata p-6 text-white font-bold text-2xl rounded-xl">
         {title}
       </div>
       <div className="flex flex-col items-center w-full">
         <p className="mb-4 font-bold text-2xl">{price}</p>
         <p>{description}</p>
         <p className="font-bold text-center p-4">WHAT'S INCLUDED</p>
-        {planRowData.map((item, index) => {
+        {planCardRow.map((item, index) => {
           return (
             <PlanRow
               key={index}
@@ -37,8 +41,14 @@ const PlansCard = ({
             />
           );
         })}
-        <div className="my-4">
-          <Button onClick={onClick} label={buttonLabel} />
+        <div className="p-4">
+          <Button
+            onClick={() => handleSignUp(planName)}
+            label={buttonLabel}
+            backgroundColor="white"
+            textColor="text-gray-800"
+            size="large"
+          />
         </div>
       </div>
     </div>

--- a/components/studentPortal/freemium/PlansCard.tsx
+++ b/components/studentPortal/freemium/PlansCard.tsx
@@ -1,5 +1,8 @@
+import { getRedirectResult } from "firebase/auth";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { useAuth } from "../../../lib/authContext";
+import { auth } from "../../../lib/firebase";
 import { PlanCard } from "../../../pages/plans";
 import { Button } from "../../ui/Button";
 import PlanRow from "./PlanRow";
@@ -12,7 +15,7 @@ const PlansCard = ({ planCard }: PlansCardProps) => {
   const { planName, title, price, description, planCardRow, buttonLabel } =
     planCard;
 
-  const { signIn } = useAuth();
+  const { signIn, user } = useAuth();
   const router = useRouter();
 
   const handleSignUp = (planName: string) => {
@@ -22,6 +25,16 @@ const PlansCard = ({ planCard }: PlansCardProps) => {
       signIn();
     }
   };
+
+  useEffect(() => {
+    async function checkAuth() {
+      const result = await getRedirectResult(auth);
+      if (result) {
+        router.push("/studentPortal");
+      }
+    }
+    checkAuth();
+  }, []);
 
   return (
     <div className="flex flex-col w-[325px] md:w-[400px] space-y-4 shadow-lg cursor-pointer rounded-xl hover:scale-105">

--- a/pages/plans.tsx
+++ b/pages/plans.tsx
@@ -1,6 +1,5 @@
 import LandingNavbar from "../components/landingPage/LandingNavbar";
 import PlansCard from "../components/studentPortal/freemium/PlansCard";
-import { useAuth } from "../lib/authContext";
 
 export type PlanCard = {
   planName: "freeTrial" | "premium";
@@ -13,7 +12,6 @@ export type PlanCard = {
 
 const Plans = (props: { planCardData: PlanCard[] }) => {
   const { planCardData } = props;
-  const { signIn } = useAuth();
 
   return (
     <div>

--- a/pages/plans.tsx
+++ b/pages/plans.tsx
@@ -1,63 +1,47 @@
-import router from "next/router";
-import React, { useState } from "react";
 import LandingNavbar from "../components/landingPage/LandingNavbar";
 import PlansCard from "../components/studentPortal/freemium/PlansCard";
-import SignInPage from "../components/welcomePage/SignInPage";
+import { useAuth } from "../lib/authContext";
 
-const Plans = ({ plansCardData }) => {
-  const [showSignInPage, setShowSignInPage] = useState(false);
+export type PlanCard = {
+  planName: "freeTrial" | "premium";
+  title: string;
+  description: string;
+  price: string;
+  buttonLabel: string;
+  planCardRow: Array<{ icon: string; description: string }>;
+};
 
-  const handlePremium = () => {
-    router.push(plansCardData[1].onClick);
-  };
-
-  const handleTrial = () => {
-    setShowSignInPage(true);
-  };
+const Plans = (props: { planCardData: PlanCard[] }) => {
+  const { planCardData } = props;
+  const { signIn } = useAuth();
 
   return (
     <div>
-      {showSignInPage ? (
-        <SignInPage />
-      ) : (
-        <div>
-          <LandingNavbar />
-          <div className="flex flex-col items-center justify-center space-y-2 mb-8">
-            <h1 className="text-charmander text-3xl font-bold text-center p-4">
-              Pick the Plan That's Right For You
-            </h1>
-            <p>Reserve your spot today!</p>
-          </div>
-          <div className="flex flex-wrap justify-center align-items-stretch md:space-x-10 space-x-0">
-            {plansCardData.map((card) => (
-              <PlansCard
-                key={card.title}
-                title={card.title}
-                description={card.description}
-                price={card.price}
-                buttonLabel={card.buttonLabel}
-                onClick={
-                  card.onClick === "/sign-up" ? handleTrial : handlePremium
-                }
-                planRowData={card.planRowData}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+      <LandingNavbar />
+      <div className="flex flex-col items-center justify-center space-y-2 mb-8">
+        <h1 className="text-charmander text-3xl font-bold text-center p-4">
+          Pick the plan that is right for you
+        </h1>
+        <p>Reserve your spot today!</p>
+      </div>
+      <div className="flex flex-wrap justify-center align-items-stretch md:space-x-10 space-x-0">
+        {planCardData.map((card, index) => (
+          <PlansCard key={index} planCard={card} />
+        ))}
+      </div>
     </div>
   );
 };
 
 export async function getServerSideProps() {
-  const plansCardData = [
+  const planCardData: PlanCard[] = [
     {
+      planName: "freeTrial",
       title: "Free 14-day Trial",
       description: "No credit card required",
       price: "$0",
       buttonLabel: "Sign Up",
-      onClick: "/sign-up",
-      planRowData: [
+      planCardRow: [
         {
           icon: "../../images/freemium/greenCheck.svg",
           description: "Two weeks access to our Coding Basics course",
@@ -86,12 +70,12 @@ export async function getServerSideProps() {
       ],
     },
     {
+      planName: "premium",
       title: "Premium",
       description: "Contact us for pricing",
       price: "Custom",
       buttonLabel: "Book a Call",
-      onClick: "https://joinskillify.com/call",
-      planRowData: [
+      planCardRow: [
         {
           icon: "../../images/freemium/greenCheck.svg",
           description: "Unlimited access to our Coding Basics course",
@@ -122,7 +106,7 @@ export async function getServerSideProps() {
   ];
   return {
     props: {
-      plansCardData: plansCardData,
+      planCardData: planCardData,
     },
   };
 }


### PR DESCRIPTION
Implemented sign up with google on the plans page. I also reworked the component and its corresponding types to be a little cleaner. When the user clicks sign up, they go to the google auth flow. Clicking on Book Call takes them to the calendly appointment page.

<img width="774" alt="image" src="https://user-images.githubusercontent.com/98791180/234379030-0f13c885-8ccb-4a95-919a-7bac4669b240.png">

A couple other things:
- there was something weird going on with the default color on the Button component not showing orange unless you hover over it... couldn't figure out exactly what was going on, but the other colors work. I thought white looked a little cleaner anyways.
- I was going to throw a google logo in the button but it was getting a little tricky with passing the right handler logic. Can definitely work this in, or add some sort of caption below the button to let the user know we only support signing in with gmail
- We should definitely test the full flow to make sure a new user routes right to the studentPortal page and sees the new modals