### PR TITLE
Address Feedback for Career Quiz

### DIFF
--- a/components/resources/quizzes/careerQuiz/CareerResults.tsx
+++ b/components/resources/quizzes/careerQuiz/CareerResults.tsx
@@ -19,7 +19,7 @@ const CareerResults = ({ onBackClick, quizViewState }: CareerResultsProps) => {
       <div className="grid text-center justify-items-center">
         <div className="font-bold mt-4 text-2xl ">YOUR RESULTS</div>
         <div className=" text-lg font-semibolds ">
-          Here are jobs in tech you’re compatible with. Click below learn more!
+          Here are jobs in tech you’re compatible with.
         </div>
         <img
           src={quizResult && quizResult.src}

--- a/components/resources/quizzes/careerQuiz/EduBackground.tsx
+++ b/components/resources/quizzes/careerQuiz/EduBackground.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { EducationState } from "../../../../pages/resources/quizzes/careerQuiz";
 import { Button } from "../../../ui/Button";
 import SkillifyNavbar from "../shared/SkillifyNavbar";
@@ -26,6 +26,8 @@ const EducationBackground = ({
   educationState,
   setEducationState,
 }: EduBackgroundProps) => {
+  const isFormValid = educationState.education;
+
   const handleInputChange = (
     name,
     event:
@@ -37,7 +39,16 @@ const EducationBackground = ({
     setEducationState({ ...educationState, [name]: value });
   };
   const [showExperienceInput, setShowExperienceInput] = useState(false);
-  const isFormValid = educationState.education;
+  useEffect(() => {
+    if (
+      educationState.education == "N/A" ||
+      educationState.education == "GED" ||
+      educationState.education == "High School Diploma"
+    ) {
+      setShowExperienceInput(true);
+    }
+  }, [isFormValid]);
+
   const handleEducationLevelChange = (
     event: React.ChangeEvent<HTMLSelectElement>
   ) => {
@@ -90,6 +101,7 @@ const EducationBackground = ({
                       type="text"
                       name="institution"
                       id="institution"
+                      value={educationState.institution}
                       onChange={(e) => handleInputChange("institution", e)}
                       className="border w-full border-gray-500 rounded-lg px-4"
                     />
@@ -109,6 +121,7 @@ const EducationBackground = ({
                   <input
                     type="text"
                     name="degree"
+                    value={educationState.degree}
                     id="degree"
                     onChange={(e) => handleInputChange("degree", e)}
                     className="shadow  w-full appearance-none border border-gray-500 rounded-lg px-4"
@@ -123,6 +136,7 @@ const EducationBackground = ({
                 <textarea
                   onChange={(e) => handleInputChange("experience", e)}
                   className="w-full border border-gray-500 rounded-lg  px-4 resize-none"
+                  value={educationState.experience}
                 />
               </div>
             )}

--- a/components/resources/quizzes/careerQuiz/EduBackground.tsx
+++ b/components/resources/quizzes/careerQuiz/EduBackground.tsx
@@ -69,7 +69,7 @@ const EducationBackground = ({
           id="education-select"
           value={educationState.education || ""}
           onChange={handleEducationLevelChange}
-          className=" border  w-full border-gray-500 rounded-lg "
+          className=" border px-4 w-full border-gray-500 rounded-lg "
         >
           {Object.values(EducationLevel).map((educationLevel) => (
             <option key={educationLevel} value={educationLevel}>
@@ -91,7 +91,7 @@ const EducationBackground = ({
                       name="institution"
                       id="institution"
                       onChange={(e) => handleInputChange("institution", e)}
-                      className="border w-full border-gray-500 rounded-lg px-2"
+                      className="border w-full border-gray-500 rounded-lg px-4"
                     />
                   </div>
                 </div>
@@ -111,7 +111,7 @@ const EducationBackground = ({
                     name="degree"
                     id="degree"
                     onChange={(e) => handleInputChange("degree", e)}
-                    className="shadow  w-full appearance-none border border-gray-500 rounded-lg px-2"
+                    className="shadow  w-full appearance-none border border-gray-500 rounded-lg px-4"
                   />
                 </div>
               )}
@@ -122,7 +122,7 @@ const EducationBackground = ({
                 </div>
                 <textarea
                   onChange={(e) => handleInputChange("experience", e)}
-                  className="w-full border border-gray-500 rounded-lg  px-2 resize-none"
+                  className="w-full border border-gray-500 rounded-lg  px-4 resize-none"
                 />
               </div>
             )}

--- a/components/resources/quizzes/shared/StartQuiz.tsx
+++ b/components/resources/quizzes/shared/StartQuiz.tsx
@@ -29,7 +29,7 @@ const StartQuiz = ({
       <div className="flex justify-center p-4 ml-16 "></div>
       <div className="flex flex-col items-center px-4 space-y-6 text-center">
         <h1 className="text-3xl font-semibold">{title}</h1>
-        <p className="px-3 text-xl font-medium">{body}</p>
+        <p className="px-4 text-xl font-medium">{body}</p>
         <div className="space-y-2 text-xl text-left">
           <h3 className="ml-8">First Name</h3>{" "}
           <input
@@ -37,7 +37,7 @@ const StartQuiz = ({
             name="name"
             value={userInput.name}
             onChange={handleInputChange}
-            className="w-4/5 ml-8 border border-gray-500 rounded-lg shadow appearance-none"
+            className="w-4/5 px-4 ml-8 border border-gray-500 rounded-lg shadow appearance-none"
           ></input>
           <h3 className="ml-8">Email Address</h3>{" "}
           <input
@@ -45,7 +45,7 @@ const StartQuiz = ({
             name="email"
             value={userInput.email}
             onChange={handleInputChange}
-            className="w-4/5 ml-8 border border-gray-500 rounded-lg shadow appearance-none"
+            className="w-4/5 ml-8 border px-4 border-gray-500 rounded-lg shadow appearance-none"
           ></input>
         </div>
         <Button


### PR DESCRIPTION
Refactored Career Quiz to address the following feedback:
- Going back to the education page now shows previously entered responses
- Added consistent `px-4` padding for all text and select inputs
- Change copy on the results page to remove “Click below to learn more”

The back-end seems to be working fine. I've not run into any more problems and reviewing the code has not revealed any cause for issue.